### PR TITLE
fix(lifecycle): take cwd from PluginInput.directory instead of process.cwd()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -347,7 +347,11 @@ const OpenCodeConfigPlugin: Plugin = async (ctx) => {
   // Batch read tool (for parallel file reads)
   const batch_read = createBatchReadTool(ctx);
 
-  const lifecycleHandle = createLifecycleStore({ runner: createLifecycleRunner(), worktreesRoot: process.cwd() });
+  const lifecycleHandle = createLifecycleStore({
+    runner: createLifecycleRunner(),
+    worktreesRoot: ctx.directory,
+    cwd: ctx.directory,
+  });
   const lifecycleTools = createLifecycleTools(lifecycleHandle);
 
   // Octto (browser-based brainstorming) tools

--- a/src/lifecycle/index.ts
+++ b/src/lifecycle/index.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path";
 import * as v from "valibot";
 
+import { config } from "@/utils/config";
 import { commitAndPush } from "./commits";
 import { renderIssueBody } from "./issue-body";
 import { finishLifecycle } from "./merge";
@@ -45,6 +46,7 @@ export interface LifecycleHandle {
 export interface LifecycleStoreInput {
   readonly runner: LifecycleRunner;
   readonly worktreesRoot: string;
+  readonly cwd: string;
   readonly baseDir?: string;
 }
 
@@ -444,8 +446,8 @@ const createStateSetter = (context: LifecycleContext): LifecycleHandle["setState
 };
 
 export function createLifecycleStore(input: LifecycleStoreInput): LifecycleHandle {
-  const store = createJsonLifecycleStore({ baseDir: input.baseDir });
-  const context = { runner: input.runner, store, worktreesRoot: input.worktreesRoot, cwd: process.cwd() };
+  const store = createJsonLifecycleStore({ baseDir: input.baseDir ?? join(input.cwd, config.lifecycle.lifecycleDir) });
+  const context = { runner: input.runner, store, worktreesRoot: input.worktreesRoot, cwd: input.cwd };
 
   return {
     start: createStart(context),

--- a/tests/integration/lifecycle-end-to-end.test.ts
+++ b/tests/integration/lifecycle-end-to-end.test.ts
@@ -190,7 +190,7 @@ describe("lifecycle scripted end-to-end", () => {
 
   it("runs the lifecycle tools through local merge and cleanup", async () => {
     const runner = createRunner(repo);
-    const handle = createLifecycleStore({ runner, worktreesRoot, baseDir: lifecycleDir });
+    const handle = createLifecycleStore({ runner, worktreesRoot, cwd: repo, baseDir: lifecycleDir });
     const tools = createLifecycleTools(handle);
 
     const startOutput = await executeTool(tools.lifecycle_start_request, {

--- a/tests/lifecycle/index.test.ts
+++ b/tests/lifecycle/index.test.ts
@@ -90,7 +90,7 @@ describe("lifecycle handle", () => {
   });
 
   it("exposes factory methods and public constants", () => {
-    const handle = createLifecycleStore({ runner: createRunner(), worktreesRoot, baseDir });
+    const handle = createLifecycleStore({ runner: createRunner(), worktreesRoot, cwd: worktreesRoot, baseDir });
 
     expect(LIFECYCLE_STATES.ABORTED).toBe("aborted");
     expect(ARTIFACT_KINDS.WORKTREE).toBe("worktree");
@@ -99,7 +99,7 @@ describe("lifecycle handle", () => {
 
   it("runs a full lifecycle with a fake runner", async () => {
     const runner = createRunner();
-    const handle = createLifecycleStore({ runner, worktreesRoot, baseDir });
+    const handle = createLifecycleStore({ runner, worktreesRoot, cwd: worktreesRoot, baseDir });
 
     const started = await handle.start({
       summary: SUMMARY,
@@ -134,7 +134,7 @@ describe("lifecycle handle", () => {
 
   it("enables issues on owned forks before opening issue", async () => {
     const runner = createRunner(createRepoView({ hasIssuesEnabled: false }));
-    const handle = createLifecycleStore({ runner, worktreesRoot, baseDir });
+    const handle = createLifecycleStore({ runner, worktreesRoot, cwd: worktreesRoot, baseDir });
 
     const record = await handle.start({ summary: SUMMARY, goals: [], constraints: [], ownerLogin: OWNER, repo: REPO });
 
@@ -149,7 +149,7 @@ describe("lifecycle handle", () => {
     const runner = createRunner(
       createRepoView({ isFork: false, parent: null, viewerPermission: "ADMIN", hasIssuesEnabled: false }),
     );
-    const handle = createLifecycleStore({ runner, worktreesRoot, baseDir });
+    const handle = createLifecycleStore({ runner, worktreesRoot, cwd: worktreesRoot, baseDir });
 
     const record = await handle.start({ summary: SUMMARY, goals: [], constraints: [], ownerLogin: OWNER, repo: REPO });
 
@@ -170,7 +170,7 @@ describe("lifecycle handle", () => {
         parent: null,
       }),
     );
-    const handle = createLifecycleStore({ runner, worktreesRoot, baseDir });
+    const handle = createLifecycleStore({ runner, worktreesRoot, cwd: worktreesRoot, baseDir });
 
     const record = await handle.start({ summary: SUMMARY, goals: [], constraints: [], ownerLogin: OWNER, repo: REPO });
 
@@ -181,7 +181,7 @@ describe("lifecycle handle", () => {
 
   it("records artifacts idempotently", async () => {
     const runner = createRunner();
-    const handle = createLifecycleStore({ runner, worktreesRoot, baseDir });
+    const handle = createLifecycleStore({ runner, worktreesRoot, cwd: worktreesRoot, baseDir });
     const started = await handle.start({ summary: SUMMARY, goals: [], constraints: [], ownerLogin: OWNER, repo: REPO });
 
     await handle.recordArtifact(started.issueNumber, ARTIFACT_KINDS.PLAN, PLAN_POINTER);
@@ -192,7 +192,7 @@ describe("lifecycle handle", () => {
 
   it("sets lifecycle state through the handle", async () => {
     const runner = createRunner();
-    const handle = createLifecycleStore({ runner, worktreesRoot, baseDir });
+    const handle = createLifecycleStore({ runner, worktreesRoot, cwd: worktreesRoot, baseDir });
     const started = await handle.start({ summary: SUMMARY, goals: [], constraints: [], ownerLogin: OWNER, repo: REPO });
 
     const record = await handle.setState(started.issueNumber, LIFECYCLE_STATES.IN_DESIGN);
@@ -201,8 +201,47 @@ describe("lifecycle handle", () => {
   });
 
   it("returns null when loading a missing record", async () => {
-    const handle = createLifecycleStore({ runner: createRunner(), worktreesRoot, baseDir });
+    const handle = createLifecycleStore({ runner: createRunner(), worktreesRoot, cwd: worktreesRoot, baseDir });
 
     await expect(handle.load(404)).resolves.toBeNull();
+  });
+
+  it("uses input.cwd (not process.cwd()) when invoking git for ownership pre-flight", async () => {
+    const customCwd = mkdtempSync(join(tmpdir(), `${PREFIX}cwd-`));
+    try {
+      const runner = createRunner();
+      const handle = createLifecycleStore({ runner, worktreesRoot, cwd: customCwd, baseDir });
+
+      await handle.start({ summary: SUMMARY, goals: [], constraints: [], ownerLogin: OWNER, repo: REPO });
+
+      const remoteCall = runner.calls.find(
+        (call) => call.bin === "git" && call.args[0] === "remote" && call.args[1] === "get-url",
+      );
+      expect(remoteCall).toBeDefined();
+      expect(remoteCall?.cwd).toBe(customCwd);
+    } finally {
+      rmSync(customCwd, { recursive: true, force: true });
+    }
+  });
+
+  it("derives store baseDir from cwd when baseDir is not provided", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), `${PREFIX}cwd-default-`));
+    try {
+      const runner = createRunner();
+      const handle = createLifecycleStore({ runner, worktreesRoot, cwd });
+
+      const started = await handle.start({
+        summary: SUMMARY,
+        goals: [],
+        constraints: [],
+        ownerLogin: OWNER,
+        repo: REPO,
+      });
+
+      const reloaded = await handle.load(started.issueNumber);
+      expect(reloaded?.issueNumber).toBe(started.issueNumber);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- `lifecycle_start_request` was always failing with `pre_flight_failed: unable to verify repository ownership` when called from inside the OpenCode plugin runtime, because `process.cwd()` there is not the project repo (typically `/root` on this host). All git / gh ownership probes were running in the wrong directory.
- Issue records were also being written to `/root/thoughts/lifecycle/` instead of the project's own `thoughts/lifecycle/`, leaking aborted records outside the repo.
- Every other hook and tool in the codebase already takes its cwd from `ctx.directory` (e.g. `file-ops-tracker`, `ledger-loader`, `mindmodel-injector`, `auto-compact`, `spawn-agent`); only the lifecycle module was the outlier.

## Fix
- `LifecycleStoreInput` now requires an explicit `cwd: string`.
- `src/index.ts` wires `cwd: ctx.directory` (and uses the same value for `worktreesRoot`).
- The lifecycle store's `baseDir` now defaults to `join(input.cwd, config.lifecycle.lifecycleDir)` when not provided, keeping records project-local.

## Tests
- New regression test: `uses input.cwd (not process.cwd()) when invoking git for ownership pre-flight` — asserts the `cwd` flows through the runner all the way to `git remote get-url origin`.
- New regression test: `derives store baseDir from cwd when baseDir is not provided` — confirms records persist under the supplied cwd.
- Existing lifecycle suites updated to pass `cwd` alongside `worktreesRoot`. End-to-end integration test now passes `cwd: repo` so the test git repo's `gh repo view` mock is reached correctly.
- Targeted `bun test tests/lifecycle tests/integration/lifecycle-end-to-end.test.ts`: **62 pass, 0 fail**.
- Full `bun run check`: biome + eslint + typecheck clean. The only failures in the full test run (octto port conflicts, octto ownership / portal sort) reproduce on `main` without these changes; they are pre-existing flakes unrelated to this fix.

## Validation log
Repro before fix:
```
$ lifecycle_start_request(...)
## Lifecycle pre-flight failed
pre_flight_failed: unable to verify repository ownership
```
After this PR (with the plugin reloaded), the same call should classify the fork correctly and proceed to issue + worktree creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)