### PR TITLE
feat(hooks): auto-rename main agent conversations on task milestones (phase 1)

### DIFF
--- a/src/hooks/conversation-title.ts
+++ b/src/hooks/conversation-title.ts
@@ -1,0 +1,197 @@
+// src/hooks/conversation-title.ts
+import type { PluginInput } from "@opencode-ai/plugin";
+
+import {
+  classifyToolMilestone,
+  createTitleStateRegistry,
+  summaryFromUserMessage,
+  TITLE_STATUS,
+  type TitleStateRegistry,
+} from "@/utils/conversation-title";
+import { extractErrorMessage } from "@/utils/errors";
+import { log } from "@/utils/logger";
+
+const LOG_SCOPE = "conversation-title";
+
+export interface ConversationTitleConfig {
+  readonly enabled: boolean;
+  readonly maxLength: number;
+  readonly isInternalSession?: (sessionID: string) => boolean;
+}
+
+const DEFAULT_MAX_LENGTH = 50;
+
+const defaultConfig = (): ConversationTitleConfig => ({
+  enabled: true,
+  maxLength: DEFAULT_MAX_LENGTH,
+});
+
+interface ToolAfterInput {
+  readonly tool: string;
+  readonly sessionID: string;
+  readonly args?: Record<string, unknown>;
+}
+
+interface ToolAfterOutput {
+  readonly output?: string;
+}
+
+interface ChatMessageInput {
+  readonly sessionID: string;
+}
+
+interface ChatMessageOutput {
+  readonly parts: readonly { readonly type: string; readonly text?: string }[];
+}
+
+interface SessionInfo {
+  readonly title: string | null;
+  readonly parentID: string | null;
+}
+
+const parentIdCache = new Map<string, string | null>();
+
+const fetchSessionInfo = async (ctx: PluginInput, sessionID: string): Promise<SessionInfo | null> => {
+  try {
+    const response = await ctx.client.session.get({
+      path: { id: sessionID },
+      query: { directory: ctx.directory },
+    });
+    const data = response.data;
+    if (!data) return null;
+    const parentID =
+      typeof (data as { parentID?: unknown }).parentID === "string" ? (data as { parentID: string }).parentID : null;
+    parentIdCache.set(sessionID, parentID);
+    return {
+      title: typeof data.title === "string" ? data.title : null,
+      parentID,
+    };
+  } catch (error) {
+    log.warn(LOG_SCOPE, `session.get failed for ${sessionID}: ${extractErrorMessage(error)}`);
+    return null;
+  }
+};
+
+const isMainAgentSession = (info: SessionInfo | null): boolean => {
+  if (!info) return false;
+  return info.parentID === null;
+};
+
+const writeTitle = async (ctx: PluginInput, sessionID: string, title: string): Promise<void> => {
+  try {
+    await ctx.client.session.update({
+      path: { id: sessionID },
+      body: { title },
+      query: { directory: ctx.directory },
+    });
+  } catch (error) {
+    log.warn(LOG_SCOPE, `session.update failed for ${sessionID}: ${extractErrorMessage(error)}`);
+  }
+};
+
+interface DispatchOptions {
+  readonly status: import("@/utils/conversation-title").TitleStatus;
+  readonly summary: string | null;
+  readonly currentTitle: string | null;
+}
+
+interface ConversationTitleHookHandlers {
+  "tool.execute.after": (input: ToolAfterInput, output: ToolAfterOutput) => Promise<void>;
+  "chat.message": (input: ChatMessageInput, output: ChatMessageOutput) => Promise<void>;
+  event: (input: { event: { type: string; properties?: unknown } }) => Promise<void>;
+}
+
+const extractMessageText = (output: ChatMessageOutput): string => {
+  return output.parts
+    .filter((p) => p.type === "text" && typeof p.text === "string")
+    .map((p) => p.text ?? "")
+    .join(" ");
+};
+
+interface ContextDeps {
+  readonly ctx: PluginInput;
+  readonly registry: TitleStateRegistry;
+  readonly config: ConversationTitleConfig;
+}
+
+const dispatch = async (deps: ContextDeps, sessionID: string, options: DispatchOptions): Promise<void> => {
+  if (deps.config.isInternalSession?.(sessionID)) return;
+
+  const info = await fetchSessionInfo(deps.ctx, sessionID);
+  if (!isMainAgentSession(info)) return;
+
+  const decision = deps.registry.decide({
+    sessionID,
+    status: options.status,
+    summary: options.summary,
+    currentTitle: options.currentTitle,
+    now: Date.now(),
+    maxLength: deps.config.maxLength,
+  });
+
+  if (decision.kind === "skip") return;
+  await writeTitle(deps.ctx, sessionID, decision.title);
+};
+
+export interface ConversationTitleHook extends ConversationTitleHookHandlers {
+  registry: TitleStateRegistry;
+}
+
+const handleToolAfter = async (deps: ContextDeps, input: ToolAfterInput, output: ToolAfterOutput): Promise<void> => {
+  if (!deps.config.enabled) return;
+  const signal = classifyToolMilestone({ tool: input.tool, args: input.args, output: output.output });
+  if (!signal) return;
+
+  const info = await fetchSessionInfo(deps.ctx, input.sessionID);
+  await dispatch(deps, input.sessionID, {
+    status: signal.status,
+    summary: signal.summary,
+    currentTitle: info?.title ?? null,
+  });
+};
+
+const handleChatMessage = async (
+  deps: ContextDeps,
+  input: ChatMessageInput,
+  output: ChatMessageOutput,
+): Promise<void> => {
+  if (!deps.config.enabled) return;
+  if (deps.registry.isOptedOut(input.sessionID)) return;
+
+  const info = await fetchSessionInfo(deps.ctx, input.sessionID);
+  if (!isMainAgentSession(info)) return;
+
+  const summary = summaryFromUserMessage(extractMessageText(output));
+  if (!summary) return;
+
+  await dispatch(deps, input.sessionID, {
+    status: TITLE_STATUS.INITIALIZING,
+    summary,
+    currentTitle: info?.title ?? null,
+  });
+};
+
+const handleEvent = (registry: TitleStateRegistry, event: { type: string; properties?: unknown }): void => {
+  if (event.type !== "session.deleted") return;
+  const props = event.properties as { info?: { id?: string } } | undefined;
+  const sessionID = props?.info?.id;
+  if (!sessionID) return;
+  registry.forget(sessionID);
+  parentIdCache.delete(sessionID);
+};
+
+export function createConversationTitleHook(
+  ctx: PluginInput,
+  overrides?: Partial<ConversationTitleConfig>,
+): ConversationTitleHook {
+  const config: ConversationTitleConfig = { ...defaultConfig(), ...overrides };
+  const registry = createTitleStateRegistry();
+  const deps: ContextDeps = { ctx, registry, config };
+
+  return {
+    registry,
+    "tool.execute.after": (input, output) => handleToolAfter(deps, input, output),
+    "chat.message": (input, output) => handleChatMessage(deps, input, output),
+    event: async ({ event }) => handleEvent(registry, event),
+  };
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -5,6 +5,11 @@ export { ConstraintViolationError, createConstraintReviewerHook } from "./constr
 export { createContextInjectorHook } from "./context-injector";
 export { type ContextWindowMonitorConfig, createContextWindowMonitorHook } from "./context-window-monitor";
 export {
+  type ConversationTitleConfig,
+  type ConversationTitleHook,
+  createConversationTitleHook,
+} from "./conversation-title";
+export {
   clearSession,
   createFetchTrackerHook,
   FETCH_TOOLS,

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
   createConstraintReviewerHook,
   createContextInjectorHook,
   createContextWindowMonitorHook,
+  createConversationTitleHook,
   createFetchTrackerHook,
   createFileOpsTrackerHook,
   createFragmentInjectorHook,
@@ -273,6 +274,11 @@ const OpenCodeConfigPlugin: Plugin = async (ctx) => {
   // Track internal sessions to prevent hook recursion (used by reviewer)
   const internalSessions = new Set<string>();
 
+  // Conversation title hook - keeps the main agent's session title in sync with milestone events
+  const conversationTitleHook = createConversationTitleHook(ctx, {
+    isInternalSession: (sessionID) => internalSessions.has(sessionID),
+  });
+
   // Mindmodel injector hook - matches tasks to patterns via keywords and injects them
   // Feature-flagged: set features.mindmodelInjection=true in micode.json to enable
   const mindmodelInjectorHook = userConfig?.features?.mindmodelInjection ? createMindmodelInjectorHook(ctx) : null;
@@ -476,6 +482,9 @@ const OpenCodeConfigPlugin: Plugin = async (ctx) => {
 
       // Check for override command
       await constraintReviewerHook["chat.message"](input, output);
+
+      // Update conversation title from the very first user message of a new session
+      await conversationTitleHook["chat.message"](input, output);
     },
 
     "chat.params": async (input, output) => {
@@ -593,6 +602,12 @@ IMPORTANT:
         { tool: input.tool, sessionID: input.sessionID, args: input.args },
         output,
       );
+
+      // Update conversation title on milestone tool events (lifecycle, plan write, executor spawn)
+      await conversationTitleHook["tool.execute.after"](
+        { tool: input.tool, sessionID: input.sessionID, args: input.args },
+        output,
+      );
     },
 
     // Transform messages: match task keywords and prepare mindmodel injection
@@ -645,6 +660,9 @@ IMPORTANT:
 
       // Fetch tracker cleanup
       await fetchTrackerHook.event({ event });
+
+      // Conversation title cleanup
+      await conversationTitleHook.event({ event });
     },
   };
 };

--- a/src/utils/conversation-title/classifier.ts
+++ b/src/utils/conversation-title/classifier.ts
@@ -1,0 +1,88 @@
+// src/utils/conversation-title/classifier.ts
+import { summaryFromPlanPath, TITLE_STATUS, type TitleStatus } from "./format";
+
+export interface ToolMilestoneInput {
+  readonly tool: string;
+  readonly args?: Record<string, unknown>;
+  readonly output?: string;
+}
+
+export interface MilestoneSignal {
+  readonly status: TitleStatus;
+  readonly summary: string | null;
+}
+
+const PLAN_PATH_FIELDS = ["filePath", "path"] as const;
+const TOOL_NAMES = {
+  WRITE: "write",
+  LIFECYCLE_START: "lifecycle_start_request",
+  LIFECYCLE_COMMIT: "lifecycle_commit",
+  LIFECYCLE_FINISH: "lifecycle_finish",
+  SPAWN_AGENT: "spawn_agent",
+} as const;
+
+const PLAN_PATH_PATTERN = /thoughts\/shared\/plans\/[^/]+\.md$/u;
+
+const stringField = (args: Record<string, unknown> | undefined, key: string): string | null => {
+  if (!args) return null;
+  const value = args[key];
+  return typeof value === "string" ? value : null;
+};
+
+const firstStringField = (args: Record<string, unknown> | undefined, keys: readonly string[]): string | null => {
+  for (const key of keys) {
+    const value = stringField(args, key);
+    if (value !== null) return value;
+  }
+  return null;
+};
+
+const detectPlanWrite = (input: ToolMilestoneInput): MilestoneSignal | null => {
+  if (input.tool.toLowerCase() !== TOOL_NAMES.WRITE) return null;
+  const path = firstStringField(input.args, PLAN_PATH_FIELDS);
+  if (!path || !PLAN_PATH_PATTERN.test(path)) return null;
+  return { status: TITLE_STATUS.PLANNING, summary: summaryFromPlanPath(path) };
+};
+
+const detectLifecycleStart = (input: ToolMilestoneInput): MilestoneSignal | null => {
+  if (input.tool !== TOOL_NAMES.LIFECYCLE_START) return null;
+  return { status: TITLE_STATUS.PLANNING, summary: stringField(input.args, "summary") };
+};
+
+const detectLifecycleCommit = (input: ToolMilestoneInput): MilestoneSignal | null => {
+  if (input.tool !== TOOL_NAMES.LIFECYCLE_COMMIT) return null;
+  return { status: TITLE_STATUS.EXECUTING, summary: stringField(input.args, "summary") };
+};
+
+const FINISH_CLOSED_PATTERN = /\bclosed\b/iu;
+
+const detectLifecycleFinish = (input: ToolMilestoneInput): MilestoneSignal | null => {
+  if (input.tool !== TOOL_NAMES.LIFECYCLE_FINISH) return null;
+  if (!input.output || !FINISH_CLOSED_PATTERN.test(input.output)) {
+    return { status: TITLE_STATUS.EXECUTING, summary: null };
+  }
+  return { status: TITLE_STATUS.DONE, summary: null };
+};
+
+const detectImplementerSpawn = (input: ToolMilestoneInput): MilestoneSignal | null => {
+  if (input.tool !== TOOL_NAMES.SPAWN_AGENT) return null;
+  const text = JSON.stringify(input.args ?? {});
+  if (!/"agent"\s*:\s*"(implementer-[^"]+|executor)"/u.test(text)) return null;
+  return { status: TITLE_STATUS.EXECUTING, summary: null };
+};
+
+const DETECTORS = [
+  detectLifecycleStart,
+  detectLifecycleCommit,
+  detectLifecycleFinish,
+  detectPlanWrite,
+  detectImplementerSpawn,
+] as const;
+
+export function classifyToolMilestone(input: ToolMilestoneInput): MilestoneSignal | null {
+  for (const detector of DETECTORS) {
+    const signal = detector(input);
+    if (signal) return signal;
+  }
+  return null;
+}

--- a/src/utils/conversation-title/format.ts
+++ b/src/utils/conversation-title/format.ts
@@ -1,0 +1,66 @@
+// src/utils/conversation-title/format.ts
+
+export const TITLE_STATUS = {
+  INITIALIZING: "初始化",
+  PLANNING: "规划中",
+  EXECUTING: "执行中",
+  DONE: "已完成",
+  FAILED: "失败",
+} as const;
+
+export type TitleStatus = (typeof TITLE_STATUS)[keyof typeof TITLE_STATUS];
+
+export interface TitleParts {
+  readonly status: TitleStatus;
+  readonly summary: string;
+}
+
+const DEFAULT_MAX_LENGTH = 50;
+const ELLIPSIS = "…";
+const SEPARATOR = ": ";
+const WHITESPACE_PATTERN = /\s+/g;
+const SPACE = " ";
+const EMPTY = "";
+
+const normalizeWhitespace = (text: string): string => text.replace(WHITESPACE_PATTERN, SPACE).trim();
+
+const truncate = (text: string, max: number): string => {
+  if (text.length <= max) return text;
+  if (max <= ELLIPSIS.length) return text.slice(0, max);
+  return `${text.slice(0, max - ELLIPSIS.length)}${ELLIPSIS}`;
+};
+
+export function buildTitle(parts: TitleParts, maxLength: number = DEFAULT_MAX_LENGTH): string {
+  const status = parts.status;
+  const summary = normalizeWhitespace(parts.summary);
+  if (summary.length === 0) return status;
+
+  const fixed = `${status}${SEPARATOR}`;
+  const remaining = maxLength - fixed.length;
+  if (remaining <= 0) return truncate(status, maxLength);
+
+  return `${fixed}${truncate(summary, remaining)}`;
+}
+
+const SLUG_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}-/;
+const PLAN_PATH_PATTERN = /thoughts\/shared\/plans\/([^/]+?)(?:-design)?\.md$/u;
+const SLUG_SEPARATORS = /[-_]+/g;
+
+export function summaryFromPlanPath(path: string | null | undefined): string | null {
+  if (!path) return null;
+  const match = PLAN_PATH_PATTERN.exec(path);
+  if (!match) return null;
+  const stem = match[1] ?? EMPTY;
+  const dateless = stem.replace(SLUG_DATE_PATTERN, EMPTY);
+  if (dateless.length === 0) return null;
+  return dateless.replace(SLUG_SEPARATORS, SPACE);
+}
+
+const FIRST_TEXT_LIMIT = 60;
+
+export function summaryFromUserMessage(text: string | null | undefined): string | null {
+  if (!text) return null;
+  const cleaned = normalizeWhitespace(text);
+  if (cleaned.length === 0) return null;
+  return cleaned.length > FIRST_TEXT_LIMIT ? cleaned.slice(0, FIRST_TEXT_LIMIT) : cleaned;
+}

--- a/src/utils/conversation-title/index.ts
+++ b/src/utils/conversation-title/index.ts
@@ -1,0 +1,16 @@
+// src/utils/conversation-title/index.ts
+export { classifyToolMilestone, type MilestoneSignal, type ToolMilestoneInput } from "./classifier";
+export {
+  buildTitle,
+  summaryFromPlanPath,
+  summaryFromUserMessage,
+  TITLE_STATUS,
+  type TitleParts,
+  type TitleStatus,
+} from "./format";
+export {
+  createTitleStateRegistry,
+  type DecisionInput,
+  type TitleDecision,
+  type TitleStateRegistry,
+} from "./state";

--- a/src/utils/conversation-title/state.ts
+++ b/src/utils/conversation-title/state.ts
@@ -1,0 +1,145 @@
+// src/utils/conversation-title/state.ts
+import { buildTitle, TITLE_STATUS, type TitleStatus } from "./format";
+
+const TITLE_THROTTLE_MS = 1000;
+const DONE_FREEZE_MS = 60_000;
+
+export const DECISION_KIND = {
+  WRITE: "write",
+  SKIP: "skip",
+} as const;
+
+export type DecisionKind = (typeof DECISION_KIND)[keyof typeof DECISION_KIND];
+
+export interface DecisionInput {
+  readonly sessionID: string;
+  readonly status: TitleStatus;
+  readonly summary: string | null;
+  readonly currentTitle: string | null;
+  readonly now: number;
+  readonly maxLength?: number;
+}
+
+export type TitleDecision =
+  | { readonly kind: typeof DECISION_KIND.WRITE; readonly title: string }
+  | { readonly kind: typeof DECISION_KIND.SKIP; readonly reason: string };
+
+interface SessionRecord {
+  lastTitle: string | null;
+  lastUpdateAt: number;
+  doneAt: number | null;
+  optedOut: boolean;
+  lastSummary: string | null;
+}
+
+export interface TitleStateRegistry {
+  decide(input: DecisionInput): TitleDecision;
+  forget(sessionID: string): void;
+  isOptedOut(sessionID: string): boolean;
+  size(): number;
+}
+
+const skip = (reason: string): TitleDecision => ({ kind: DECISION_KIND.SKIP, reason });
+
+const isUserAuthoredTitle = (current: string | null, lastWritten: string | null): boolean => {
+  if (current === null || current === "") return false;
+  if (lastWritten === null) return true;
+  return current !== lastWritten;
+};
+
+const detectOptOut = (record: SessionRecord, current: string | null): boolean => {
+  if (record.optedOut) return true;
+  if (record.lastTitle === null) return false;
+  return isUserAuthoredTitle(current, record.lastTitle);
+};
+
+const isDoneFrozen = (record: SessionRecord, now: number): boolean => {
+  if (record.doneAt === null) return false;
+  return now - record.doneAt < DONE_FREEZE_MS;
+};
+
+const isThrottled = (record: SessionRecord, candidate: string, now: number): boolean => {
+  if (record.lastTitle !== candidate) return false;
+  return now - record.lastUpdateAt < TITLE_THROTTLE_MS;
+};
+
+const ensureSummary = (input: DecisionInput, record: SessionRecord): string | null => {
+  return input.summary ?? record.lastSummary;
+};
+
+const updateRecord = (
+  record: SessionRecord,
+  title: string,
+  status: TitleStatus,
+  summary: string | null,
+  now: number,
+): void => {
+  record.lastTitle = title;
+  record.lastUpdateAt = now;
+  record.lastSummary = summary;
+  if (status === TITLE_STATUS.DONE) {
+    record.doneAt = now;
+    return;
+  }
+  if (record.doneAt !== null && now - record.doneAt >= DONE_FREEZE_MS) {
+    record.doneAt = null;
+  }
+};
+
+const newRecord = (): SessionRecord => ({
+  lastTitle: null,
+  lastUpdateAt: 0,
+  doneAt: null,
+  optedOut: false,
+  lastSummary: null,
+});
+
+export function createTitleStateRegistry(): TitleStateRegistry {
+  const records = new Map<string, SessionRecord>();
+
+  const getOrCreate = (sessionID: string): SessionRecord => {
+    let record = records.get(sessionID);
+    if (!record) {
+      record = newRecord();
+      records.set(sessionID, record);
+    }
+    return record;
+  };
+
+  return {
+    decide(input) {
+      const record = getOrCreate(input.sessionID);
+
+      if (detectOptOut(record, input.currentTitle)) {
+        record.optedOut = true;
+        return skip("opted-out");
+      }
+
+      if (isDoneFrozen(record, input.now)) {
+        return skip("done-frozen");
+      }
+
+      const summary = ensureSummary(input, record);
+      const title = buildTitle({ status: input.status, summary: summary ?? "" }, input.maxLength);
+
+      if (isThrottled(record, title, input.now)) {
+        return skip("throttled");
+      }
+
+      updateRecord(record, title, input.status, summary, input.now);
+      return { kind: DECISION_KIND.WRITE, title };
+    },
+
+    forget(sessionID) {
+      records.delete(sessionID);
+    },
+
+    isOptedOut(sessionID) {
+      return records.get(sessionID)?.optedOut ?? false;
+    },
+
+    size() {
+      return records.size;
+    },
+  };
+}

--- a/tests/hooks/conversation-title.test.ts
+++ b/tests/hooks/conversation-title.test.ts
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import type { PluginInput } from "@opencode-ai/plugin";
+
+import { createConversationTitleHook } from "@/hooks";
+
+interface FakeSession {
+  readonly id: string;
+  readonly title: string | null;
+  readonly parentID: string | null;
+}
+
+interface UpdateCall {
+  readonly id: string;
+  readonly title: string;
+}
+
+interface Harness {
+  readonly ctx: PluginInput;
+  readonly sessions: Map<string, FakeSession>;
+  readonly updates: UpdateCall[];
+}
+
+const SESSION_MAIN = "ses_main";
+const SESSION_CHILD = "ses_child";
+const SESSION_INTERNAL = "ses_internal";
+
+const createHarness = (): Harness => {
+  const sessions = new Map<string, FakeSession>();
+  const updates: UpdateCall[] = [];
+
+  const ctx = {
+    directory: "/tmp/fake-project",
+    client: {
+      session: {
+        get: async ({ path }: { path: { id: string } }) => {
+          const session = sessions.get(path.id);
+          if (!session) return { data: undefined };
+          return { data: { id: session.id, title: session.title, parentID: session.parentID } };
+        },
+        update: async ({ path, body }: { path: { id: string }; body: { title?: string } }) => {
+          if (typeof body.title !== "string") return { data: undefined };
+          updates.push({ id: path.id, title: body.title });
+          const existing = sessions.get(path.id);
+          if (existing) sessions.set(path.id, { ...existing, title: body.title });
+          return { data: { id: path.id } };
+        },
+      },
+    },
+  } as unknown as PluginInput;
+
+  return { ctx, sessions, updates };
+};
+
+describe("conversation-title hook", () => {
+  let harness: Harness;
+
+  beforeEach(() => {
+    harness = createHarness();
+    harness.sessions.set(SESSION_MAIN, { id: SESSION_MAIN, title: null, parentID: null });
+    harness.sessions.set(SESSION_CHILD, { id: SESSION_CHILD, title: null, parentID: SESSION_MAIN });
+    harness.sessions.set(SESSION_INTERNAL, { id: SESSION_INTERNAL, title: null, parentID: null });
+  });
+
+  it("renames the main session when a plan file is written", async () => {
+    const hook = createConversationTitleHook(harness.ctx);
+
+    await hook["tool.execute.after"](
+      {
+        tool: "write",
+        sessionID: SESSION_MAIN,
+        args: { filePath: "thoughts/shared/plans/2026-04-27-foo-design.md" },
+      },
+      { output: "" },
+    );
+
+    expect(harness.updates).toHaveLength(1);
+    expect(harness.updates[0]?.id).toBe(SESSION_MAIN);
+    expect(harness.updates[0]?.title).toBe("规划中: foo");
+  });
+
+  it("ignores non-milestone tool events", async () => {
+    const hook = createConversationTitleHook(harness.ctx);
+
+    await hook["tool.execute.after"](
+      { tool: "read", sessionID: SESSION_MAIN, args: { filePath: "src/index.ts" } },
+      { output: "" },
+    );
+
+    expect(harness.updates).toHaveLength(0);
+  });
+
+  it("never renames a child session that has parentID set", async () => {
+    const hook = createConversationTitleHook(harness.ctx);
+
+    await hook["tool.execute.after"](
+      {
+        tool: "lifecycle_start_request",
+        sessionID: SESSION_CHILD,
+        args: { summary: "child work", goals: [], constraints: [] },
+      },
+      { output: "" },
+    );
+
+    expect(harness.updates).toHaveLength(0);
+  });
+
+  it("respects the isInternalSession predicate from the host", async () => {
+    const hook = createConversationTitleHook(harness.ctx, {
+      isInternalSession: (id) => id === SESSION_INTERNAL,
+    });
+
+    await hook["tool.execute.after"](
+      {
+        tool: "lifecycle_start_request",
+        sessionID: SESSION_INTERNAL,
+        args: { summary: "internal work", goals: [], constraints: [] },
+      },
+      { output: "" },
+    );
+
+    expect(harness.updates).toHaveLength(0);
+  });
+
+  it("renames on the first user message of a session", async () => {
+    const hook = createConversationTitleHook(harness.ctx);
+
+    await hook["chat.message"](
+      { sessionID: SESSION_MAIN },
+      { parts: [{ type: "text", text: "  设计 对话名 自动更新  " }] },
+    );
+
+    expect(harness.updates).toHaveLength(1);
+    expect(harness.updates[0]?.title).toBe("初始化: 设计 对话名 自动更新");
+  });
+
+  it("opts out after the user manually edits the title", async () => {
+    const hook = createConversationTitleHook(harness.ctx);
+
+    await hook["tool.execute.after"](
+      {
+        tool: "lifecycle_start_request",
+        sessionID: SESSION_MAIN,
+        args: { summary: "auto rename", goals: [], constraints: [] },
+      },
+      { output: "" },
+    );
+    expect(harness.updates).toHaveLength(1);
+
+    harness.sessions.set(SESSION_MAIN, { id: SESSION_MAIN, title: "我自己取的名字", parentID: null });
+    await Bun.sleep(2);
+
+    await hook["tool.execute.after"](
+      {
+        tool: "lifecycle_commit",
+        sessionID: SESSION_MAIN,
+        args: { issue_number: 1, scope: "x", summary: "should-not-write" },
+      },
+      { output: "" },
+    );
+
+    expect(harness.updates).toHaveLength(1);
+    expect(hook.registry.isOptedOut(SESSION_MAIN)).toBe(true);
+  });
+
+  it("forgets per-session state on session.deleted event", async () => {
+    const hook = createConversationTitleHook(harness.ctx);
+
+    await hook["tool.execute.after"](
+      {
+        tool: "lifecycle_start_request",
+        sessionID: SESSION_MAIN,
+        args: { summary: "x", goals: [], constraints: [] },
+      },
+      { output: "" },
+    );
+    expect(hook.registry.size()).toBe(1);
+
+    await hook.event({ event: { type: "session.deleted", properties: { info: { id: SESSION_MAIN } } } });
+    expect(hook.registry.size()).toBe(0);
+  });
+
+  it("swallows session.update errors and never throws", async () => {
+    const ctx = {
+      directory: "/tmp/fake-project",
+      client: {
+        session: {
+          get: async () => ({ data: { id: SESSION_MAIN, title: null, parentID: null } }),
+          update: async () => {
+            throw new Error("network down");
+          },
+        },
+      },
+    } as unknown as PluginInput;
+
+    const hook = createConversationTitleHook(ctx);
+
+    await expect(
+      hook["tool.execute.after"](
+        {
+          tool: "lifecycle_start_request",
+          sessionID: SESSION_MAIN,
+          args: { summary: "x", goals: [], constraints: [] },
+        },
+        { output: "" },
+      ),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/tests/utils/conversation-title/classifier.test.ts
+++ b/tests/utils/conversation-title/classifier.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "bun:test";
+
+import { classifyToolMilestone, TITLE_STATUS } from "@/utils/conversation-title";
+
+describe("classifyToolMilestone", () => {
+  it("recognizes a plan write under thoughts/shared/plans/", () => {
+    const signal = classifyToolMilestone({
+      tool: "write",
+      args: { filePath: "thoughts/shared/plans/2026-04-27-foo-design.md", content: "..." },
+    });
+    expect(signal?.status).toBe(TITLE_STATUS.PLANNING);
+    expect(signal?.summary).toBe("foo");
+  });
+
+  it("ignores write to other directories", () => {
+    const signal = classifyToolMilestone({
+      tool: "write",
+      args: { filePath: "src/index.ts" },
+    });
+    expect(signal).toBeNull();
+  });
+
+  it("maps lifecycle_start_request with summary arg", () => {
+    const signal = classifyToolMilestone({
+      tool: "lifecycle_start_request",
+      args: { summary: "auto conversation title", goals: [], constraints: [] },
+    });
+    expect(signal?.status).toBe(TITLE_STATUS.PLANNING);
+    expect(signal?.summary).toBe("auto conversation title");
+  });
+
+  it("maps lifecycle_commit to executing", () => {
+    const signal = classifyToolMilestone({
+      tool: "lifecycle_commit",
+      args: { issue_number: 1, scope: "title", summary: "wire hook" },
+    });
+    expect(signal?.status).toBe(TITLE_STATUS.EXECUTING);
+    expect(signal?.summary).toBe("wire hook");
+  });
+
+  it("maps lifecycle_finish to done when output mentions closed", () => {
+    const signal = classifyToolMilestone({
+      tool: "lifecycle_finish",
+      args: { issue_number: 1 },
+      output: "merged and closed",
+    });
+    expect(signal?.status).toBe(TITLE_STATUS.DONE);
+  });
+
+  it("maps lifecycle_finish without closed marker to executing", () => {
+    const signal = classifyToolMilestone({
+      tool: "lifecycle_finish",
+      args: { issue_number: 1 },
+      output: "still in progress",
+    });
+    expect(signal?.status).toBe(TITLE_STATUS.EXECUTING);
+  });
+
+  it("recognizes spawn_agent with implementer-* agents", () => {
+    const signal = classifyToolMilestone({
+      tool: "spawn_agent",
+      args: { agents: [{ agent: "implementer-frontend", prompt: "x", description: "y" }] },
+    });
+    expect(signal?.status).toBe(TITLE_STATUS.EXECUTING);
+  });
+
+  it("recognizes spawn_agent with executor agent", () => {
+    const signal = classifyToolMilestone({
+      tool: "spawn_agent",
+      args: { agents: { agent: "executor", prompt: "x", description: "y" } },
+    });
+    expect(signal?.status).toBe(TITLE_STATUS.EXECUTING);
+  });
+
+  it("ignores spawn_agent for other agent types", () => {
+    const signal = classifyToolMilestone({
+      tool: "spawn_agent",
+      args: { agents: [{ agent: "codebase-locator", prompt: "x", description: "y" }] },
+    });
+    expect(signal).toBeNull();
+  });
+
+  it("ignores unknown tools", () => {
+    expect(classifyToolMilestone({ tool: "read", args: { filePath: "anything.md" } })).toBeNull();
+  });
+});

--- a/tests/utils/conversation-title/format.test.ts
+++ b/tests/utils/conversation-title/format.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "bun:test";
+
+import { buildTitle, summaryFromPlanPath, summaryFromUserMessage, TITLE_STATUS } from "@/utils/conversation-title";
+
+describe("buildTitle", () => {
+  it("joins status and summary with a colon and ascii space", () => {
+    expect(buildTitle({ status: TITLE_STATUS.EXECUTING, summary: "自动重命名" })).toBe("执行中: 自动重命名");
+  });
+
+  it("returns status alone when summary is empty", () => {
+    expect(buildTitle({ status: TITLE_STATUS.PLANNING, summary: "" })).toBe(TITLE_STATUS.PLANNING);
+  });
+
+  it("normalizes runs of whitespace inside the summary", () => {
+    expect(buildTitle({ status: TITLE_STATUS.EXECUTING, summary: "fix\n  bug \t now" })).toBe("执行中: fix bug now");
+  });
+
+  it("truncates summary with an ellipsis when total exceeds maxLength", () => {
+    const summary = "0123456789".repeat(8);
+    const title = buildTitle({ status: TITLE_STATUS.EXECUTING, summary }, 20);
+    expect(title.length).toBeLessThanOrEqual(20);
+    expect(title.startsWith("执行中: ")).toBe(true);
+    expect(title.endsWith("…")).toBe(true);
+  });
+
+  it("falls back to truncated status when even the prefix overflows maxLength", () => {
+    const title = buildTitle({ status: TITLE_STATUS.EXECUTING, summary: "anything" }, 1);
+    expect(title.length).toBeLessThanOrEqual(1);
+  });
+});
+
+describe("summaryFromPlanPath", () => {
+  it("strips date prefix and -design suffix from a plan slug", () => {
+    expect(summaryFromPlanPath("thoughts/shared/plans/2026-04-27-auto-conversation-title-design.md")).toBe(
+      "auto conversation title",
+    );
+  });
+
+  it("returns null for non-plan paths", () => {
+    expect(summaryFromPlanPath("src/index.ts")).toBeNull();
+  });
+
+  it("returns null for empty input", () => {
+    expect(summaryFromPlanPath(null)).toBeNull();
+    expect(summaryFromPlanPath(undefined)).toBeNull();
+  });
+});
+
+describe("summaryFromUserMessage", () => {
+  it("trims and collapses whitespace", () => {
+    expect(summaryFromUserMessage("  hello   world  ")).toBe("hello world");
+  });
+
+  it("caps at 60 characters", () => {
+    const long = "x".repeat(120);
+    const result = summaryFromUserMessage(long);
+    expect(result).toBeDefined();
+    expect((result as string).length).toBe(60);
+  });
+
+  it("returns null for empty inputs", () => {
+    expect(summaryFromUserMessage("")).toBeNull();
+    expect(summaryFromUserMessage("   ")).toBeNull();
+    expect(summaryFromUserMessage(null)).toBeNull();
+  });
+});

--- a/tests/utils/conversation-title/state.test.ts
+++ b/tests/utils/conversation-title/state.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "bun:test";
+
+import { createTitleStateRegistry, TITLE_STATUS } from "@/utils/conversation-title";
+
+const SESSION = "ses_main";
+const NOW = 1_700_000_000_000;
+
+describe("title state registry", () => {
+  it("emits a write decision on the first milestone for a session", () => {
+    const registry = createTitleStateRegistry();
+    const decision = registry.decide({
+      sessionID: SESSION,
+      status: TITLE_STATUS.PLANNING,
+      summary: "foo",
+      currentTitle: null,
+      now: NOW,
+    });
+    expect(decision.kind).toBe("write");
+    if (decision.kind === "write") {
+      expect(decision.title).toBe("规划中: foo");
+    }
+  });
+
+  it("throttles a second write of the same title within 1 second", () => {
+    const registry = createTitleStateRegistry();
+    const first = registry.decide({
+      sessionID: SESSION,
+      status: TITLE_STATUS.PLANNING,
+      summary: "foo",
+      currentTitle: null,
+      now: NOW,
+    });
+    expect(first.kind).toBe("write");
+
+    const second = registry.decide({
+      sessionID: SESSION,
+      status: TITLE_STATUS.PLANNING,
+      summary: "foo",
+      currentTitle: first.kind === "write" ? first.title : null,
+      now: NOW + 200,
+    });
+    expect(second.kind).toBe("skip");
+    if (second.kind === "skip") {
+      expect(second.reason).toBe("throttled");
+    }
+  });
+
+  it("allows a different title to be written even within throttle window", () => {
+    const registry = createTitleStateRegistry();
+    const first = registry.decide({
+      sessionID: SESSION,
+      status: TITLE_STATUS.PLANNING,
+      summary: "foo",
+      currentTitle: null,
+      now: NOW,
+    });
+    if (first.kind !== "write") throw new Error("expected first write");
+
+    const next = registry.decide({
+      sessionID: SESSION,
+      status: TITLE_STATUS.EXECUTING,
+      summary: "foo",
+      currentTitle: first.title,
+      now: NOW + 200,
+    });
+    expect(next.kind).toBe("write");
+    if (next.kind === "write") {
+      expect(next.title).toBe("执行中: foo");
+    }
+  });
+
+  it("opts out of further writes when the user manually edits the title", () => {
+    const registry = createTitleStateRegistry();
+    const first = registry.decide({
+      sessionID: SESSION,
+      status: TITLE_STATUS.PLANNING,
+      summary: "foo",
+      currentTitle: null,
+      now: NOW,
+    });
+    if (first.kind !== "write") throw new Error("expected first write");
+
+    const userEdited = registry.decide({
+      sessionID: SESSION,
+      status: TITLE_STATUS.EXECUTING,
+      summary: "bar",
+      currentTitle: "我的对话",
+      now: NOW + 5000,
+    });
+    expect(userEdited.kind).toBe("skip");
+    if (userEdited.kind === "skip") {
+      expect(userEdited.reason).toBe("opted-out");
+    }
+    expect(registry.isOptedOut(SESSION)).toBe(true);
+
+    const later = registry.decide({
+      sessionID: SESSION,
+      status: TITLE_STATUS.EXECUTING,
+      summary: "baz",
+      currentTitle: "我的对话",
+      now: NOW + 10_000,
+    });
+    expect(later.kind).toBe("skip");
+  });
+
+  it("freezes the title in done status for one minute", () => {
+    const registry = createTitleStateRegistry();
+    const finish = registry.decide({
+      sessionID: SESSION,
+      status: TITLE_STATUS.DONE,
+      summary: "all done",
+      currentTitle: null,
+      now: NOW,
+    });
+    if (finish.kind !== "write") throw new Error("expected write on done");
+
+    const within = registry.decide({
+      sessionID: SESSION,
+      status: TITLE_STATUS.EXECUTING,
+      summary: "newer",
+      currentTitle: finish.title,
+      now: NOW + 30_000,
+    });
+    expect(within.kind).toBe("skip");
+    if (within.kind === "skip") {
+      expect(within.reason).toBe("done-frozen");
+    }
+  });
+
+  it("releases the done freeze after 60 seconds", () => {
+    const registry = createTitleStateRegistry();
+    const finish = registry.decide({
+      sessionID: SESSION,
+      status: TITLE_STATUS.DONE,
+      summary: "done",
+      currentTitle: null,
+      now: NOW,
+    });
+    if (finish.kind !== "write") throw new Error("expected write on done");
+
+    const after = registry.decide({
+      sessionID: SESSION,
+      status: TITLE_STATUS.EXECUTING,
+      summary: "next phase",
+      currentTitle: finish.title,
+      now: NOW + 70_000,
+    });
+    expect(after.kind).toBe("write");
+  });
+
+  it("forgets per-session state when forget() is called", () => {
+    const registry = createTitleStateRegistry();
+    registry.decide({
+      sessionID: SESSION,
+      status: TITLE_STATUS.PLANNING,
+      summary: "foo",
+      currentTitle: null,
+      now: NOW,
+    });
+    expect(registry.size()).toBe(1);
+    registry.forget(SESSION);
+    expect(registry.size()).toBe(0);
+  });
+
+  it("reuses the previous summary when a milestone has none", () => {
+    const registry = createTitleStateRegistry();
+    const first = registry.decide({
+      sessionID: SESSION,
+      status: TITLE_STATUS.PLANNING,
+      summary: "auto conversation title",
+      currentTitle: null,
+      now: NOW,
+    });
+    if (first.kind !== "write") throw new Error("expected first write");
+
+    const next = registry.decide({
+      sessionID: SESSION,
+      status: TITLE_STATUS.EXECUTING,
+      summary: null,
+      currentTitle: first.title,
+      now: NOW + 5_000,
+    });
+    expect(next.kind).toBe("write");
+    if (next.kind === "write") {
+      expect(next.title).toBe("执行中: auto conversation title");
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Adds a \`conversation-title\` hook so the OpenCode session list reflects what each main-agent session is actually doing. Title becomes \`<状态>: <摘要>\` (≤ 50 chars), driven by milestone events from existing tools.

## Design
Captured in \`thoughts/shared/plans/2026-04-27-auto-conversation-title-design.md\` (gitignored) — branch chose:
- 1a milestone trigger
- 2a + 2c conditional issue prefix
- 3a Hook + SDK probe
- 4a main agent only

This PR implements **phase 1** of that design: classifier + format + state registry + main hook, no \`#issue\` prefix yet (deferred to phase 2).

## Behaviour
- **Trigger**: \`tool.execute.after\` (lifecycle_start_request, lifecycle_commit, lifecycle_finish, write to \`thoughts/shared/plans/*.md\`, executor / implementer-* spawn) and \`chat.message\` (first user turn) classified into milestone signals.
- **Title format**: \`<状态>: <摘要>\` where 状态 ∈ {初始化, 规划中, 执行中, 已完成, 失败}, total length ≤ 50 chars with ellipsis truncation. Status-only title when summary is empty.
- **Scope strictly limited to the user's main session**: any session with \`parentID\` set, or any session matching the host-injected \`isInternalSession\` predicate (e.g. \`constraint-reviewer\`), is skipped.
- **User-edit opt-out**: live title differs from the one we last wrote ⇒ session enters sticky opt-out, never auto-renamed again until \`session.deleted\`.
- **Throttle**: identical title within 1 s ⇒ skip; \`已完成\` freezes further writes for 60 s; missing summary on a milestone reuses the last summary.
- **Failure-safe**: \`client.session.update\` errors caught + logged, never thrown.

## Module layout
Mirrors the \`file-ops-tracker\` pattern (factory + per-session in-memory state):

\`\`\`
src/hooks/conversation-title.ts                  # main hook factory
src/utils/conversation-title/
  classifier.ts                                  # ToolMilestoneInput → MilestoneSignal
  format.ts                                      # TITLE_STATUS, buildTitle, summary helpers
  state.ts                                       # createTitleStateRegistry: throttle + opt-out + done-freeze
  index.ts                                       # barrel
src/index.ts                                     # wired after internalSessions
src/hooks/index.ts                               # public re-export
\`\`\`

## Tests (37 new, all green)
- \`tests/utils/conversation-title/format.test.ts\`: status+summary join, whitespace, ellipsis truncation, plan slug, user-message clipping
- \`tests/utils/conversation-title/classifier.test.ts\`: each detector, agent allowlist, ignored tools
- \`tests/utils/conversation-title/state.test.ts\`: first write, throttle, different-title pass-through, opt-out, done freeze + 60 s release, summary fallback, forget()
- \`tests/hooks/conversation-title.test.ts\`: end-to-end with fake \`client.session.{get,update}\` covering main rename, child-session skip, isInternalSession skip, first-message rename, opt-out persistence, session.deleted cleanup, swallowed errors

## Validation
- \`bun test tests/utils/conversation-title tests/hooks/conversation-title.test.ts\`: 37 pass / 0 fail.
- \`bun run check\` (full): biome + eslint + typecheck clean. Test suite has 14 pre-existing failures unrelated to this PR (octto port-conflict + portal sort), confirmed by stashing the diff and re-running on \`main\`.

## Phase 2 (next PR, not in scope here)
Add lifecycle store reverse lookup (cwd / branch → issueNumber, 60 s cache) and prepend \`#<issue> \` to the title when the active session belongs to a tracked lifecycle. Pulls in \`@/lifecycle\`, otherwise no behaviour change.

## Depends on
- #2 (\`fix(lifecycle): take cwd from PluginInput.directory…\`) is a separate fix unrelated to this hook, but lands first because the lifecycle tools used in the milestone classifier are unusable without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)