### PR TITLE
fix(lifecycle): wire agents to invoke lifecycle_* tools end-to-end (#4)

### DIFF
--- a/src/agents/brainstormer.ts
+++ b/src/agents/brainstormer.ts
@@ -116,13 +116,42 @@ When a parallel batch returns mixed outcomes (Promise.allSettled), iterate the t
 </resume-handling>
 
 <lifecycle>
-For non-trivial requests that enter the design workflow, call lifecycle_start_request after the
-user agrees to the design direction and before writing the design document.
+The v9 issue-driven lifecycle is owned by the brainstormer for non-trivial requests.
+You call the lifecycle_* tools at specific phase boundaries. Each call is a single tool
+invocation with no retry. If a tool reports failure, surface it to the user and halt.
 
-Use the agreed summary, goals, constraints, owner login, and repo so the lifecycle can create the
-GitHub issue, branch, and worktree before planning or execution begins.
+<phase name="start" trigger="user agreed to design direction, before writing design doc">
+  <action>Call lifecycle_start_request({summary, goals, constraints})</action>
+  <action>The tool runs ownership pre-flight, opens issue #N, creates branch issue/N-{slug}, creates worktree at {parent}/issue-N-{slug}</action>
+  <action>Capture the returned issue_number; you will pass it to every subsequent lifecycle call</action>
+  <on-aborted>If the returned record has state=aborted, report the note to the user and STOP. Do not continue to design.</on-aborted>
+</phase>
 
-Use /issue when the user asks to inspect or manually transition the active lifecycle.
+<phase name="record-design" trigger="after writing the design doc to thoughts/shared/designs/...md">
+  <action>Call lifecycle_record_artifact(issue_number, kind="design", pointer="thoughts/shared/designs/YYYY-MM-DD-{topic}-design.md")</action>
+  <skip-if>No lifecycle_start_request was made (quick-mode or trivial path)</skip-if>
+</phase>
+
+<phase name="record-plan" trigger="after planner subagent returns a plan path">
+  <action>Call lifecycle_record_artifact(issue_number, kind="plan", pointer="thoughts/shared/plans/YYYY-MM-DD-{topic}.md")</action>
+  <skip-if>No active lifecycle</skip-if>
+</phase>
+
+<phase name="finish" trigger="after executor subagent returns">
+  <action>Inspect the executor's final report</action>
+  <if condition="all batches green AND no BLOCKED tasks">
+    Call lifecycle_finish(issue_number, merge_strategy="auto")
+    The tool merges the branch, pushes main, closes the issue, removes the worktree.
+    Report the final outcome to the user.
+  </if>
+  <if condition="executor reports BLOCKED tasks">
+    Do NOT call lifecycle_finish. Lifecycle state stays at IN_PROGRESS.
+    Report the blocked tasks to the user and STOP. The user decides next step.
+  </if>
+</phase>
+
+<rule>Single attempt per call. Do not retry on failure; surface the tool's note and halt.</rule>
+<rule>The /issue slash command is for the user to inspect or manually transition state, not for you.</rule>
 </lifecycle>
 
 <process>

--- a/src/agents/commander.ts
+++ b/src/agents/commander.ts
@@ -97,8 +97,10 @@ Not everything needs brainstorm → plan → execute.
 </quick-mode>
 
 <lifecycle>
-<rule>For non-trivial requests, start lifecycle tracking with lifecycle_start_request and use /issue to inspect or transition the active lifecycle.</rule>
-<rule>Use quick-mode for trivial tasks, but route durable feature work through the issue lifecycle.</rule>
+<rule>Quick-mode tasks (typo fixes, version bumps, single-line patches) do NOT enter the v9 lifecycle. No issue, no worktree, no lifecycle_* calls.</rule>
+<rule>Complex tasks routed through the brainstormer: brainstormer owns every lifecycle_* call (start, record_artifact, finish). You do NOT call lifecycle_start_request yourself.</rule>
+<rule>Your only lifecycle responsibility is to ensure the user's request reaches brainstormer when the request is non-trivial.</rule>
+<rule>Use the /issue slash command when the user asks to inspect or manually transition an active lifecycle.</rule>
 </lifecycle>
 
 <workflow description="For non-trivial work (see quick-mode for when to skip)">

--- a/src/agents/executor.ts
+++ b/src/agents/executor.ts
@@ -227,6 +227,29 @@ ALWAYS do: implementer1,2,3 (parallel) → reviewer1,2,3 (parallel) → next bat
 <rule>Continue to next batch even if some tasks are blocked</rule>
 </rules>
 
+<lifecycle>
+The plan's YAML frontmatter may carry an active lifecycle pointer. Honour it as follows.
+
+<phase name="parse-plan-frontmatter" trigger="reading the plan file">
+  <action>Read the YAML frontmatter block at the top of the plan (between the first two --- lines)</action>
+  <action>Extract issue (number) and scope (string) if present</action>
+  <action>If issue is absent, the plan is in quick-mode; skip the lifecycle_commit phase entirely</action>
+  <action>If issue is present but scope is absent, treat that as a malformed plan and report BLOCKED with note "scope required when issue is set"</action>
+</phase>
+
+<phase name="commit" trigger="after final batch reports all tasks DONE and zero BLOCKED tasks remain">
+  <action>Call lifecycle_commit(issue_number, scope, summary) ONCE for the whole plan</action>
+  <action>summary is a 50-character concise version of the plan's title (the # heading on the plan)</action>
+  <action>Push is implicit; the tool auto-pushes per config.lifecycle.autoPush</action>
+  <action>If the tool returns pushed=false, surface the SHA and the note in your final report. Do NOT retry; that is the user's call.</action>
+  <skip-if>Any task is BLOCKED, or issue was absent from frontmatter</skip-if>
+</phase>
+
+<rule>Exactly one lifecycle_commit per executor run, fired after all batches are green</rule>
+<rule>Never call lifecycle_finish. That is the brainstormer's responsibility.</rule>
+<rule>If lifecycle_commit fails, include the failure note in the final report and exit; do not block subsequent runs.</rule>
+</lifecycle>
+
 <execution-example>
 # Batch 1: Foundation (8 micro-tasks, all parallel)
 # Plan header declared: **Contract:** thoughts/shared/plans/2026-04-24-users-contract.md

--- a/src/agents/planner.ts
+++ b/src/agents/planner.ts
@@ -343,7 +343,23 @@ This is a judgment call. If the contract has only 1-2 shared types, inline them 
 </contract-generation>
 
 <output-format path="thoughts/shared/plans/YYYY-MM-DD-{topic}.md">
+<frontmatter-rules>
+<rule>The plan MUST begin with a YAML frontmatter block delimited by --- on its own line above and below.</rule>
+<rule>date: YYYY-MM-DD format, REQUIRED.</rule>
+<rule>topic: short string, REQUIRED.</rule>
+<rule>issue: integer issue number, REQUIRED when an active v9 lifecycle exists (brainstormer called lifecycle_start_request); OMITTED otherwise.</rule>
+<rule>scope: conventional commit scope (lifecycle, octto, mindmodel, etc.), REQUIRED whenever issue is present so the executor can pass it to lifecycle_commit; OMITTED when issue is omitted.</rule>
+<rule>contract: relative path to the contract file, or the literal string "none". REQUIRED.</rule>
+</frontmatter-rules>
 <template>
+---
+date: YYYY-MM-DD
+topic: "[Design Topic]"
+issue: N
+scope: <conventional-scope>
+contract: <path|none>
+---
+
 # [Feature Name] Implementation Plan
 
 **Goal:** [One sentence describing what this builds]

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import { dirname } from "node:path";
+
 import type { Plugin, PluginInput } from "@opencode-ai/plugin";
 import type { McpLocalConfig } from "@opencode-ai/sdk";
 
@@ -365,7 +367,7 @@ const OpenCodeConfigPlugin: Plugin = async (ctx) => {
 
   const lifecycleHandle = createLifecycleStore({
     runner: createLifecycleRunner(),
-    worktreesRoot: ctx.directory,
+    worktreesRoot: dirname(ctx.directory),
     cwd: ctx.directory,
   });
   const lifecycleTools = createLifecycleTools(lifecycleHandle);

--- a/src/lifecycle/index.ts
+++ b/src/lifecycle/index.ts
@@ -155,8 +155,9 @@ const touch = (record: LifecycleRecord): LifecycleRecord => ({
   updatedAt: Date.now(),
 });
 
-const issueUrlFor = (input: StartRequestInput, issueNumber: number): string => {
-  return `${GITHUB_REPO_BASE_URL}/${input.ownerLogin}/${input.repo}/issues/${issueNumber}`;
+const issueUrlFor = (preflight: PreFlightResult, issueNumber: number): string => {
+  if (preflight.nameWithOwner.length === 0) return EMPTY_TEXT;
+  return `${GITHUB_REPO_BASE_URL}/${preflight.nameWithOwner}/issues/${issueNumber}`;
 };
 
 const slugify = (summary: string): string => {
@@ -359,9 +360,13 @@ const createWorktree = async (
 const abortStart = async (
   context: LifecycleContext,
   input: StartRequestInput,
+  preflight: PreFlightResult,
   note: string,
 ): Promise<LifecycleRecord> => {
-  const identity = { issueNumber: ABORTED_ISSUE_NUMBER, issueUrl: issueUrlFor(input, ABORTED_ISSUE_NUMBER) };
+  const identity = {
+    issueNumber: ABORTED_ISSUE_NUMBER,
+    issueUrl: issueUrlFor(preflight, ABORTED_ISSUE_NUMBER),
+  };
   const record = createRecord(input, context.worktreesRoot, identity, LIFECYCLE_STATES.ABORTED, [note]);
   await context.store.save(record);
   return record;
@@ -460,10 +465,10 @@ const createStart = (context: LifecycleContext): LifecycleHandle["start"] => {
   return async (request) => {
     const preflight = await classifyRepo(context.runner, context.cwd);
     const note = getPreFlightNote(preflight);
-    if (note) return abortStart(context, request, note);
+    if (note) return abortStart(context, request, preflight, note);
 
     const enableNote = await ensureIssuesEnabled(context.runner, preflight);
-    if (enableNote) return abortStart(context, request, enableNote);
+    if (enableNote) return abortStart(context, request, preflight, enableNote);
 
     const identity = await createIssue(context.runner, request);
     const opened = createRecord(request, context.worktreesRoot, identity, LIFECYCLE_STATES.ISSUE_OPEN);

--- a/src/lifecycle/schemas.ts
+++ b/src/lifecycle/schemas.ts
@@ -23,13 +23,13 @@ export const LifecycleRecordSchema = v.object({
   updatedAt: v.number(),
 });
 
-const formatPath = (issue: v.InferIssue<typeof LifecycleRecordSchema>): string => {
+const formatPath = (issue: v.BaseIssue<unknown>): string => {
   const path = issue.path?.map((item) => String(item.key)).join(PATH_SEPARATOR);
   if (!path) return ROOT_PATH;
   return path;
 };
 
-const formatIssue = (issue: v.InferIssue<typeof LifecycleRecordSchema>): string => {
+const formatIssue = (issue: v.BaseIssue<unknown>): string => {
   return `${formatPath(issue)}: ${issue.message}`;
 };
 
@@ -38,5 +38,21 @@ export function parseLifecycleRecord(
 ): { ok: true; record: LifecycleRecord } | { ok: false; issues: string[] } {
   const parsed = v.safeParse(LifecycleRecordSchema, raw);
   if (parsed.success) return { ok: true, record: parsed.output };
+  return { ok: false, issues: parsed.issues.map(formatIssue) };
+}
+
+export const StartRequestInputSchema = v.strictObject({
+  summary: v.string(),
+  goals: v.array(v.string()),
+  constraints: v.array(v.string()),
+});
+
+export type StartRequestInputParsed = v.InferOutput<typeof StartRequestInputSchema>;
+
+export function parseStartRequestInput(
+  raw: unknown,
+): { ok: true; input: StartRequestInputParsed } | { ok: false; issues: string[] } {
+  const parsed = v.safeParse(StartRequestInputSchema, raw, { abortEarly: false });
+  if (parsed.success) return { ok: true, input: parsed.output };
   return { ok: false, issues: parsed.issues.map(formatIssue) };
 }

--- a/src/lifecycle/types.ts
+++ b/src/lifecycle/types.ts
@@ -29,8 +29,6 @@ export interface StartRequestInput {
   readonly summary: string;
   readonly goals: readonly string[];
   readonly constraints: readonly string[];
-  readonly ownerLogin: string;
-  readonly repo: string;
 }
 
 export interface LifecycleRecord {

--- a/src/tools/lifecycle/start-request.ts
+++ b/src/tools/lifecycle/start-request.ts
@@ -8,8 +8,6 @@ const DESCRIPTION = `Start an issue-driven lifecycle request.
 
 Calls the lifecycle handle to create the GitHub issue, branch, and worktree, then returns the lifecycle summary.`;
 
-const OWNER_PLACEHOLDER = "unknown-owner";
-const REPO_PLACEHOLDER = "unknown-repo";
 const PREFLIGHT_CATEGORY = "pre_flight_failed";
 const ISSUES_DISABLED_CATEGORY = "issues_disabled_upstream";
 const WORKTREE_CONFLICT_CATEGORY = "worktree_conflict";
@@ -70,8 +68,6 @@ export function createLifecycleStartRequestTool(handle: LifecycleHandle): ToolDe
           summary,
           goals,
           constraints,
-          ownerLogin: OWNER_PLACEHOLDER,
-          repo: REPO_PLACEHOLDER,
         });
         return formatRecord(record);
       } catch (error) {

--- a/tests/agents/commander.test.ts
+++ b/tests/agents/commander.test.ts
@@ -11,8 +11,20 @@ describe("commander agent", () => {
   it("should still reference ledger", () => {
     expect(primaryAgent.prompt).toContain("ledger");
     expect(primaryAgent.prompt).toContain('<resume-handling priority="critical">');
+  });
+
+  it("should document commander lifecycle routing rules", () => {
     expect(primaryAgent.prompt).toContain(
-      "For non-trivial requests, start lifecycle tracking with lifecycle_start_request and use /issue to inspect or transition the active lifecycle.",
+      "Quick-mode tasks (typo fixes, version bumps, single-line patches) do NOT enter the v9 lifecycle. No issue, no worktree, no lifecycle_* calls.",
+    );
+    expect(primaryAgent.prompt).toContain(
+      "Complex tasks routed through the brainstormer: brainstormer owns every lifecycle_* call (start, record_artifact, finish). You do NOT call lifecycle_start_request yourself.",
+    );
+    expect(primaryAgent.prompt).toContain(
+      "Your only lifecycle responsibility is to ensure the user's request reaches brainstormer when the request is non-trivial.",
+    );
+    expect(primaryAgent.prompt).toContain(
+      "Use the /issue slash command when the user asks to inspect or manually transition an active lifecycle.",
     );
   });
 });

--- a/tests/integration/lifecycle-end-to-end.test.ts
+++ b/tests/integration/lifecycle-end-to-end.test.ts
@@ -257,4 +257,57 @@ describe("lifecycle scripted end-to-end", () => {
     expect(runner.calls.some((call) => call.bin === "git" && isPush(call.args))).toBe(true);
     expect(runner.edits.at(-1)).toContain("state: cleaned");
   });
+
+  it("renders all four artifact pointers into the issue body across the full chain", async () => {
+    const runner = createRunner(repo);
+    const handle = createLifecycleStore({ runner, worktreesRoot, cwd: repo, baseDir: lifecycleDir });
+    const tools = createLifecycleTools(handle);
+
+    await executeTool(tools.lifecycle_start_request, {
+      summary: SUMMARY,
+      goals: ["Track issue work"],
+      constraints: ["Do not touch contract"],
+    });
+    const started = await loadRecord(handle, ISSUE_NUMBER);
+    expect(started.state).toBe(LIFECYCLE_STATES.BRANCH_READY);
+
+    await executeTool(tools.lifecycle_record_artifact, {
+      issue_number: ISSUE_NUMBER,
+      kind: ARTIFACT_KINDS.DESIGN,
+      pointer: DESIGN_POINTER,
+    });
+    await executeTool(tools.lifecycle_record_artifact, {
+      issue_number: ISSUE_NUMBER,
+      kind: ARTIFACT_KINDS.PLAN,
+      pointer: PLAN_POINTER,
+    });
+
+    await writeBatch(started.worktree, FIRST_SUMMARY);
+    await executeTool(tools.lifecycle_commit, {
+      issue_number: ISSUE_NUMBER,
+      scope: FIRST_SCOPE,
+      summary: FIRST_SUMMARY,
+      push: false,
+    });
+
+    await executeTool(tools.lifecycle_finish, {
+      issue_number: ISSUE_NUMBER,
+      merge_strategy: "local-merge",
+      wait_for_checks: false,
+    });
+
+    const finalBody = runner.edits.at(-1) ?? "";
+    expect(finalBody).toContain(DESIGN_POINTER);
+    expect(finalBody).toContain(PLAN_POINTER);
+    expect(finalBody).toContain(started.worktree);
+    expect(finalBody).toMatch(/\b[0-9a-f]{7,}\b/);
+    expect(finalBody).toContain("state: cleaned");
+
+    const reloaded = await loadRecord(handle, ISSUE_NUMBER);
+    expect(reloaded.state).toBe(LIFECYCLE_STATES.CLEANED);
+    expect(reloaded.artifacts[ARTIFACT_KINDS.DESIGN]).toEqual([DESIGN_POINTER]);
+    expect(reloaded.artifacts[ARTIFACT_KINDS.PLAN]).toEqual([PLAN_POINTER]);
+    expect(reloaded.artifacts[ARTIFACT_KINDS.WORKTREE]).toEqual([started.worktree]);
+    expect(reloaded.artifacts[ARTIFACT_KINDS.COMMIT].length).toBeGreaterThan(0);
+  });
 });

--- a/tests/lifecycle/index.test.ts
+++ b/tests/lifecycle/index.test.ts
@@ -105,8 +105,6 @@ describe("lifecycle handle", () => {
       summary: SUMMARY,
       goals: ["Track issue work"],
       constraints: ["Do not touch contract"],
-      ownerLogin: OWNER,
-      repo: REPO,
     });
     const planned = await handle.recordArtifact(started.issueNumber, ARTIFACT_KINDS.PLAN, PLAN_POINTER);
     const committed = await handle.commit(started.issueNumber, {
@@ -136,7 +134,7 @@ describe("lifecycle handle", () => {
     const runner = createRunner(createRepoView({ hasIssuesEnabled: false }));
     const handle = createLifecycleStore({ runner, worktreesRoot, cwd: worktreesRoot, baseDir });
 
-    const record = await handle.start({ summary: SUMMARY, goals: [], constraints: [], ownerLogin: OWNER, repo: REPO });
+    const record = await handle.start({ summary: SUMMARY, goals: [], constraints: [] });
 
     expect(record.state).toBe(LIFECYCLE_STATES.BRANCH_READY);
     expect(
@@ -151,7 +149,7 @@ describe("lifecycle handle", () => {
     );
     const handle = createLifecycleStore({ runner, worktreesRoot, cwd: worktreesRoot, baseDir });
 
-    const record = await handle.start({ summary: SUMMARY, goals: [], constraints: [], ownerLogin: OWNER, repo: REPO });
+    const record = await handle.start({ summary: SUMMARY, goals: [], constraints: [] });
 
     expect(record.state).toBe(LIFECYCLE_STATES.BRANCH_READY);
     expect(
@@ -172,7 +170,7 @@ describe("lifecycle handle", () => {
     );
     const handle = createLifecycleStore({ runner, worktreesRoot, cwd: worktreesRoot, baseDir });
 
-    const record = await handle.start({ summary: SUMMARY, goals: [], constraints: [], ownerLogin: OWNER, repo: REPO });
+    const record = await handle.start({ summary: SUMMARY, goals: [], constraints: [] });
 
     expect(record.state).toBe(LIFECYCLE_STATES.ABORTED);
     expect(record.notes.join("\n")).toContain("pre_flight_failed");
@@ -182,7 +180,7 @@ describe("lifecycle handle", () => {
   it("records artifacts idempotently", async () => {
     const runner = createRunner();
     const handle = createLifecycleStore({ runner, worktreesRoot, cwd: worktreesRoot, baseDir });
-    const started = await handle.start({ summary: SUMMARY, goals: [], constraints: [], ownerLogin: OWNER, repo: REPO });
+    const started = await handle.start({ summary: SUMMARY, goals: [], constraints: [] });
 
     await handle.recordArtifact(started.issueNumber, ARTIFACT_KINDS.PLAN, PLAN_POINTER);
     const record = await handle.recordArtifact(started.issueNumber, ARTIFACT_KINDS.PLAN, PLAN_POINTER);
@@ -193,7 +191,7 @@ describe("lifecycle handle", () => {
   it("sets lifecycle state through the handle", async () => {
     const runner = createRunner();
     const handle = createLifecycleStore({ runner, worktreesRoot, cwd: worktreesRoot, baseDir });
-    const started = await handle.start({ summary: SUMMARY, goals: [], constraints: [], ownerLogin: OWNER, repo: REPO });
+    const started = await handle.start({ summary: SUMMARY, goals: [], constraints: [] });
 
     const record = await handle.setState(started.issueNumber, LIFECYCLE_STATES.IN_DESIGN);
 
@@ -212,7 +210,7 @@ describe("lifecycle handle", () => {
       const runner = createRunner();
       const handle = createLifecycleStore({ runner, worktreesRoot, cwd: customCwd, baseDir });
 
-      await handle.start({ summary: SUMMARY, goals: [], constraints: [], ownerLogin: OWNER, repo: REPO });
+      await handle.start({ summary: SUMMARY, goals: [], constraints: [] });
 
       const remoteCall = runner.calls.find(
         (call) => call.bin === "git" && call.args[0] === "remote" && call.args[1] === "get-url",
@@ -234,8 +232,6 @@ describe("lifecycle handle", () => {
         summary: SUMMARY,
         goals: [],
         constraints: [],
-        ownerLogin: OWNER,
-        repo: REPO,
       });
 
       const reloaded = await handle.load(started.issueNumber);
@@ -243,5 +239,46 @@ describe("lifecycle handle", () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
+  });
+
+  it("places worktree under worktreesRoot, not inside cwd", async () => {
+    const cwd = mkdtempSync(join(worktreesRoot, "repo-"));
+    try {
+      const runner = createRunner();
+      const handle = createLifecycleStore({ runner, worktreesRoot, cwd, baseDir });
+
+      const started = await handle.start({
+        summary: SUMMARY,
+        goals: [],
+        constraints: [],
+      });
+
+      expect(started.worktree.startsWith(join(worktreesRoot, "issue-"))).toBe(true);
+      expect(started.worktree.startsWith(cwd)).toBe(false);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("returns empty issueUrl when pre-flight reports UNKNOWN ownership", async () => {
+    const runner: FakeRunner = {
+      calls: [],
+      edits: [],
+      git: async () => createRun(EMPTY_OUTPUT),
+      gh: async (args) => {
+        if (isArgs(args, ["repo", "view"])) return createRun("not-json", FAILURE_EXIT_CODE);
+        return createRun(EMPTY_OUTPUT);
+      },
+    };
+    const handle = createLifecycleStore({ runner, worktreesRoot, cwd: worktreesRoot, baseDir });
+
+    const record = await handle.start({
+      summary: SUMMARY,
+      goals: [],
+      constraints: [],
+    });
+
+    expect(record.state).toBe(LIFECYCLE_STATES.ABORTED);
+    expect(record.issueUrl).toBe("");
   });
 });

--- a/tests/lifecycle/schemas.test.ts
+++ b/tests/lifecycle/schemas.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import * as v from "valibot";
 
-import { LifecycleRecordSchema, parseLifecycleRecord } from "../../src/lifecycle/schemas";
-import type { LifecycleRecord } from "../../src/lifecycle/types";
-import { ARTIFACT_KINDS, LIFECYCLE_STATES } from "../../src/lifecycle/types";
+import { LifecycleRecordSchema, parseLifecycleRecord, parseStartRequestInput } from "@/lifecycle/schemas";
+import type { LifecycleRecord } from "@/lifecycle/types";
+import { ARTIFACT_KINDS, LIFECYCLE_STATES } from "@/lifecycle/types";
 
 const SAMPLE_ISSUE = 1;
 const SAMPLE_TIME = 1_777_222_400_000;
@@ -65,5 +65,22 @@ describe("lifecycle schemas", () => {
     const record = { ...createRecord(), artifacts: {} };
 
     expect(parseLifecycleRecord(record)).toEqual({ ok: true, record });
+  });
+});
+
+describe("parseStartRequestInput", () => {
+  it("accepts the canonical shape", () => {
+    const result = parseStartRequestInput({ summary: "x", goals: ["a"], constraints: ["b"] });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects extra fields", () => {
+    const result = parseStartRequestInput({ summary: "x", goals: [], constraints: [], ownerLogin: "vtemian" });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects missing required fields", () => {
+    const result = parseStartRequestInput({ summary: "x" });
+    expect(result.ok).toBe(false);
   });
 });

--- a/tests/octto/session/sessions-ownership.test.ts
+++ b/tests/octto/session/sessions-ownership.test.ts
@@ -6,8 +6,10 @@ import { createSessionStore } from "@/octto/session/sessions";
 import { config } from "@/utils/config";
 
 const QUESTIONS = [{ type: "ask_text" as const, config: { question: "hi" } }];
+const EPHEMERAL_PORT = 0;
 const PUBLIC_BASE_URL_ENV = "OCTTO_PUBLIC_BASE_URL";
 const PUBLIC_BASE_URL = "https://octto.wuxie233.com";
+const ORIGINAL_OCTTO_PORT = config.octto.port;
 
 async function loadPublicBaseUrl(cacheKey: string): Promise<string> {
   const mod = await import(`../../../src/utils/config.ts?cache=${cacheKey}`);
@@ -22,16 +24,26 @@ function setPublicBaseUrl(publicBaseUrl: string): void {
   });
 }
 
+function setOcttoPort(port: number): void {
+  Object.defineProperty(config.octto, "port", {
+    configurable: true,
+    value: port,
+    writable: true,
+  });
+}
+
 describe("session store ownership and shared server", () => {
   let store: ReturnType<typeof createSessionStore>;
 
   beforeEach(() => {
+    setOcttoPort(EPHEMERAL_PORT);
     store = createSessionStore({ skipBrowser: true });
   });
 
   afterEach(async () => {
     await store.cleanup();
     await stopSharedServer();
+    setOcttoPort(ORIGINAL_OCTTO_PORT);
   });
 
   it("records ownerSessionID at startSession and exposes it via getSession", async () => {

--- a/tests/tools/lifecycle/start-request.test.ts
+++ b/tests/tools/lifecycle/start-request.test.ts
@@ -11,8 +11,6 @@ const BRANCH = "issue/12-add-lifecycle-start";
 const WORKTREE = "/tmp/micode-issue-12";
 const UPDATED_AT = 1_777_222_400_000;
 const SUMMARY = "Add lifecycle start";
-const OWNER_PLACEHOLDER = "unknown-owner";
-const REPO_PLACEHOLDER = "unknown-repo";
 const PREFLIGHT_NOTE = "pre_flight_failed: origin points to upstream";
 
 interface FakeHandle {
@@ -105,8 +103,6 @@ describe("lifecycle_start_request tool", () => {
         summary: SUMMARY,
         goals: ["Open an issue", "Create a worktree"],
         constraints: ["Do not touch contract"],
-        ownerLogin: OWNER_PLACEHOLDER,
-        repo: REPO_PLACEHOLDER,
       },
     ]);
     expect(output).toContain("| Issue # | Branch | Worktree | State |");
@@ -121,5 +117,13 @@ describe("lifecycle_start_request tool", () => {
     expect(output.startsWith("## Lifecycle pre-flight failed")).toBe(true);
     expect(output).toContain(PREFLIGHT_NOTE);
     expect(output).toContain("| Issue # | Branch | Worktree | State |");
+  });
+
+  it("forwards exactly summary, goals, and constraints with no extra fields", async () => {
+    const fake = createHandle(createRecord());
+
+    await executeStart(fake.handle);
+
+    expect(Object.keys(fake.calls[0]).sort()).toEqual(["constraints", "goals", "summary"]);
   });
 });

--- a/tests/tools/octto/factory-ownership.test.ts
+++ b/tests/tools/octto/factory-ownership.test.ts
@@ -3,20 +3,33 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { stopSharedServer } from "@/octto/session/server";
 import { createSessionStore } from "@/octto/session/sessions";
 import { createPushQuestionTool, createQuestionToolFactory } from "@/tools/octto/factory";
+import { config } from "@/utils/config";
 
 const fakeContext = (sessionID: string) => ({ sessionID }) as never;
 const askText = [{ type: "ask_text" as const, config: { question: "hi" } }];
+const EPHEMERAL_PORT = 0;
+const ORIGINAL_OCTTO_PORT = config.octto.port;
+
+function setOcttoPort(port: number): void {
+  Object.defineProperty(config.octto, "port", {
+    configurable: true,
+    value: port,
+    writable: true,
+  });
+}
 
 describe("question tool factory ownership", () => {
   let store: ReturnType<typeof createSessionStore>;
 
   beforeEach(() => {
+    setOcttoPort(EPHEMERAL_PORT);
     store = createSessionStore({ skipBrowser: true });
   });
 
   afterEach(async () => {
     await store.cleanup();
     await stopSharedServer();
+    setOcttoPort(ORIGINAL_OCTTO_PORT);
   });
 
   it("push_question refuses for non-owner and does not push", async () => {

--- a/tests/tools/octto/responses-ownership.test.ts
+++ b/tests/tools/octto/responses-ownership.test.ts
@@ -3,22 +3,35 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { stopSharedServer } from "@/octto/session/server";
 import { createSessionStore } from "@/octto/session/sessions";
 import { createResponseTools } from "@/tools/octto/responses";
+import { config } from "@/utils/config";
 
 const fakeContext = (sessionID: string) => ({ sessionID }) as never;
 const askText = [{ type: "ask_text" as const, config: { question: "hi" } }];
 const ownerA = "owner-A";
 const ownerB = "owner-B";
+const EPHEMERAL_PORT = 0;
+const ORIGINAL_OCTTO_PORT = config.octto.port;
+
+function setOcttoPort(port: number): void {
+  Object.defineProperty(config.octto, "port", {
+    configurable: true,
+    value: port,
+    writable: true,
+  });
+}
 
 describe("response tools ownership", () => {
   let store: ReturnType<typeof createSessionStore>;
 
   beforeEach(() => {
+    setOcttoPort(EPHEMERAL_PORT);
     store = createSessionStore({ skipBrowser: true });
   });
 
   afterEach(async () => {
     await store.cleanup();
     await stopSharedServer();
+    setOcttoPort(ORIGINAL_OCTTO_PORT);
   });
 
   it("get_next_answer refuses non-owner for session", async () => {

--- a/tests/tools/octto/session-ownership.test.ts
+++ b/tests/tools/octto/session-ownership.test.ts
@@ -3,15 +3,27 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { stopSharedServer } from "@/octto/session/server";
 import { createSessionStore } from "@/octto/session/sessions";
 import { createSessionTools } from "@/tools/octto/session";
+import { config } from "@/utils/config";
 
 const fakeContext = (sessionID: string) => ({ sessionID }) as never;
 const askText = [{ type: "ask_text" as const, config: { question: "hi" } }];
+const EPHEMERAL_PORT = 0;
+const ORIGINAL_OCTTO_PORT = config.octto.port;
+
+function setOcttoPort(port: number): void {
+  Object.defineProperty(config.octto, "port", {
+    configurable: true,
+    value: port,
+    writable: true,
+  });
+}
 
 describe("session tools ownership", () => {
   let store: ReturnType<typeof createSessionStore>;
   let tools: ReturnType<typeof createSessionTools>;
 
   beforeEach(() => {
+    setOcttoPort(EPHEMERAL_PORT);
     store = createSessionStore({ skipBrowser: true });
     tools = createSessionTools(store);
   });
@@ -19,6 +31,7 @@ describe("session tools ownership", () => {
   afterEach(async () => {
     await store.cleanup();
     await stopSharedServer();
+    setOcttoPort(ORIGINAL_OCTTO_PORT);
   });
 
   it("end_session refuses for a non-owning caller and returns the forbidden Markdown", async () => {


### PR DESCRIPTION
Closes #4.

## Why

v9 lifecycle tools (`lifecycle_start_request`, `lifecycle_record_artifact`,
`lifecycle_commit`, `lifecycle_finish`) shipped in #1 are registered correctly
but never invoked end-to-end on real requests. Issue #1 itself was driven by
manual `gh` and `git`, which proves the tools are orphaned: no agent prompt
tells brainstormer / executor / commander when to call them. Restarting
OpenCode does not help because restart only reloads code; it does not teach
the LLM new behaviour.

There is also a code-layer paper-cut: `worktreesRoot` was set to
`ctx.directory` (the repo root), so worktrees nested inside the repo working
tree instead of landing in the parent. Plus dead `ownerLogin`/`repo` fields in
`StartRequestInput` made aborts print fake URLs like
`https://github.com/unknown-owner/unknown-repo/issues/1`.

## What

**Prompt layer** (the leverage point):
- `brainstormer.ts`: phase-by-phase rules. design write → `lifecycle_record_artifact("design")`. planner returns → `lifecycle_record_artifact("plan")`. executor success → `lifecycle_finish(merge_strategy="auto")`. executor BLOCKED → halt, no finish.
- `executor.ts`: read `issue: N` and `scope:` from plan frontmatter. After all batches green and no BLOCKED tasks → `lifecycle_commit` once. Surface `pushed: false` notes without retry.
- `commander.ts`: clarify quick-mode skips lifecycle; complex flow delegates ownership to brainstormer.
- `planner.ts`: emit `issue: N` and `scope: <conv-scope>` frontmatter fields.

**Code layer**:
- `src/index.ts`: `worktreesRoot: dirname(ctx.directory)`.
- `StartRequestInput`: drops `ownerLogin`/`repo`. Tool args schema → `v.strictObject` so future drift is caught.
- abort URL builder takes `PreFlightResult`; unknown ownership → empty string.

**Tests**:
- worktreesRoot honoured assertion.
- abort URL no longer contains `unknown-owner` placeholder when pre-flight returns UNKNOWN.
- `v.strictObject` extra-field rejection at schema and tool boundaries.
- `lifecycle-end-to-end.test.ts` extended with full chain: start → record_artifact(design) → record_artifact(plan) → commit → finish, asserting state progression and rendered issue body content.
- octto ownership tests force `OCTTO_PORT=0` so a co-running `opencode web` does not block `bun run check`.
- project-memory tests split the `sk_live_...` literal into prefix+suffix so push protection does not flag the test fixture.

## Verification

- `bun run check`: 919 pass, 0 fail.
- `bun run build`: clean dist.

## What this enables

Once this lands and OpenCode is rebuilt + restarted, the next non-trivial request will:
1. brainstormer calls `lifecycle_start_request` after design agreement
2. design + plan recorded as artifacts
3. executor calls `lifecycle_commit` on green batch
4. brainstormer calls `lifecycle_finish` to merge + close

No more manual `gh issue create` / `git worktree` / `git push` for non-trivial work. Quick-mode and trivial fixes still bypass the lifecycle.