### PR TITLE
feat(tdd): narrow required tests to path policy

### DIFF
--- a/src/agents/planner.ts
+++ b/src/agents/planner.ts
@@ -39,7 +39,7 @@ Goal: 10-20 implementers running simultaneously on independent files.
   <rule>FILL GAPS CONFIDENTLY: If design doesn't specify implementation details, make the call yourself.</rule>
   <rule>Every code example MUST be complete - never write "add validation here"</rule>
   <rule>Every file path MUST be exact - never write "somewhere in src/"</rule>
-  <rule>Follow TDD: failing test → verify fail → implement → verify pass</rule>
+  <rule>Follow TDD when Test is not "none": failing test → verify fail → implement → verify pass. Set Test to "none" when the file does not match REQUIRED_TEST_PATHS (regex: ^src/utils/, word-boundary schemas?.ts$, word-boundary parsers?.ts$). This decision is regex-driven, not LLM judgment-driven.</rule>
   <rule priority="HIGH">MINIMAL RESEARCH: Most plans need 0-3 subagent calls total. Use tools directly first.</rule>
   <rule priority="HIGH">SKELETON-THEN-FILL: Plan files are written via skeleton Write + per-batch Edit. See <write-protocol>.</rule>
 </critical-rules>
@@ -446,7 +446,7 @@ Tasks: 4.1, 4.2
 <task-node-format description="Shape of each Task block. Phase 2 Edits replace BATCH-N-TASKS with one of these per task in batch N.">
 ### Task N.M: [Config/Type/Schema/Module/Component Name]
 **File:** \`exact/path/to/file.ts\`
-**Test:** \`tests/exact/path/to/file.test.ts\` (or "none" for configs)
+**Test:** \`tests/exact/path/to/file.test.ts\` (or "none" when the file does not match REQUIRED_TEST_PATHS)
 **Depends:** none | 1.1, 1.2 (imports types from these)
 **Domain:** frontend | backend | general
 
@@ -594,7 +594,7 @@ spawn_agent(agent="pattern-finder", prompt="Find auth middleware patterns", desc
   <principle name="zero-context">Implementer knows nothing about codebase</principle>
   <principle name="complete-code">Every code block is copy-paste ready</principle>
   <principle name="exact-paths">Every file path is absolute from project root</principle>
-  <principle name="tdd-always">Every file has a corresponding test file</principle>
+  <principle name="tdd-required-paths">TDD is required only when the task's Test field is not "none". The test field is "none" when the file does not match REQUIRED_TEST_PATHS (regex-driven, not LLM judgment). Current REQUIRED_TEST_PATHS patterns: ^src/utils/, word-boundary schemas?.ts$, word-boundary parsers?.ts$</principle>
   <principle name="verify-everything">Every task has a verification command</principle>
   <principle name="domain-tagged">Every task carries a Domain tag (frontend, backend, or general); the executor dispatches based on this tag</principle>
   <principle name="contract-when-cross-domain">Produce a companion contract file whenever the plan spans both frontend and backend</principle>

--- a/src/agents/reviewer.ts
+++ b/src/agents/reviewer.ts
@@ -89,13 +89,26 @@ Quick review - you're one of 10-20 reviewers running in parallel.
 </section>
 </checklist>
 
+<required-test-paths-policy>
+The planner marks Test as "none" for files that do not match REQUIRED_TEST_PATHS.
+REQUIRED_TEST_PATHS patterns: ^src/utils/, word-boundary schemas?.ts$, word-boundary parsers?.ts$.
+When Test is "none":
+- "Test: none" is a normal, valid plan value. Do NOT flag it as missing or incomplete.
+- Skip all test-exists and test-passes checks.
+- Continue all other checks: correctness, style, mindmodel compliance, safety.
+When Test has an actual path:
+- The test file MUST exist and MUST pass. Fail closed as before.
+- Do NOT approve when a required test is absent or failing.
+Do NOT reject a task solely because its Test is "none" — the REQUIRED_TEST_PATHS decision
+is regex-driven by the planner, not subject to reviewer override.
+</required-test-paths-policy>
+
 <process>
-<step>Parse prompt for: task ID, file path, test path</step>
+<step>Parse prompt for: task ID, file path, test path (may be "none")</step>
 <step>Call mindmodel_lookup for relevant project patterns (architecture, components, error handling)</step>
 <step>Read the implementation file</step>
-<step>Read the test file</step>
-<step>Run the test command</step>
-<step>Verify test passes</step>
+<step>If test path is not "none": read the test file and run the test command</step>
+<step>If test path is "none": skip test-exists and test-passes checks (see required-test-paths-policy)</step>
 <step>Check against project patterns from mindmodel - not personal preference</step>
 <step>Report APPROVED or CHANGES REQUESTED</step>
 </process>
@@ -103,7 +116,8 @@ Quick review - you're one of 10-20 reviewers running in parallel.
 <micro-task-scope>
 You review ONE file. Keep review focused:
 - Does the file exist and have correct content?
-- Does the test exist and pass?
+- If Test is not "none": does the test exist and pass?
+- If Test is "none": skip test checks — this is intentional per REQUIRED_TEST_PATHS policy.
 - Any obvious bugs or security issues?
 - Don't nitpick style if functionality is correct.
 </micro-task-scope>

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -336,3 +336,22 @@ export const config = {
 
 /** Plugin fallback model — single source of truth for the default model string */
 export const DEFAULT_MODEL = config.model.default;
+
+/**
+ * Paths that always require a corresponding test file.
+ * The regex is matched against the implementation file path (relative from project root).
+ * Patterns:
+ *   1. Anything under src/utils/ — shared utilities tend to be high-leverage and easy to unit-test.
+ *   2. Files whose basename is schema.ts / schemas.ts — Valibot/Zod schema definitions must be exercised.
+ *   3. Files whose basename is parser.ts / parsers.ts — parsing logic has well-defined inputs/outputs.
+ */
+export const REQUIRED_TEST_PATHS: readonly RegExp[] = [/^src\/utils\//, /\bschemas?\.ts$/, /\bparsers?\.ts$/] as const;
+
+/**
+ * Returns true when the given file path matches at least one of REQUIRED_TEST_PATHS,
+ * meaning the planner must emit a test file for it and the reviewer must verify it.
+ * The decision is regex-driven, not LLM judgment-driven.
+ */
+export function requiresTest(filePath: string): boolean {
+  return REQUIRED_TEST_PATHS.some((pattern) => pattern.test(filePath));
+}

--- a/tests/utils/required-test-paths.test.ts
+++ b/tests/utils/required-test-paths.test.ts
@@ -1,0 +1,95 @@
+// tests/utils/required-test-paths.test.ts
+import { describe, expect, it } from "bun:test";
+
+import { REQUIRED_TEST_PATHS, requiresTest } from "@/utils/config";
+
+describe("REQUIRED_TEST_PATHS", () => {
+  it("exports a non-empty readonly array of RegExp patterns", () => {
+    expect(Array.isArray(REQUIRED_TEST_PATHS)).toBe(true);
+    expect(REQUIRED_TEST_PATHS.length).toBe(3);
+    for (const pattern of REQUIRED_TEST_PATHS) {
+      expect(pattern).toBeInstanceOf(RegExp);
+    }
+  });
+});
+
+describe("requiresTest — positive: src/utils/ prefix", () => {
+  it("matches a direct file under src/utils/", () => {
+    expect(requiresTest("src/utils/config.ts")).toBe(true);
+  });
+
+  it("matches a nested file under src/utils/", () => {
+    expect(requiresTest("src/utils/runtime-deploy/index.ts")).toBe(true);
+  });
+
+  it("matches src/utils/parser-test/foo.ts because of the src/utils/ prefix", () => {
+    expect(requiresTest("src/utils/parser-test/foo.ts")).toBe(true);
+  });
+});
+
+describe("requiresTest — positive: schema(s).ts basename", () => {
+  it("matches schema.ts in any directory", () => {
+    expect(requiresTest("src/lifecycle/schema.ts")).toBe(true);
+  });
+
+  it("matches schemas.ts in any directory", () => {
+    expect(requiresTest("src/octto/schemas.ts")).toBe(true);
+  });
+
+  it("matches schema.ts at project root depth", () => {
+    expect(requiresTest("schema.ts")).toBe(true);
+  });
+
+  it("matches a deeply nested schema.ts", () => {
+    expect(requiresTest("src/a/b/c/schema.ts")).toBe(true);
+  });
+});
+
+describe("requiresTest — positive: parser(s).ts basename", () => {
+  it("matches parser.ts in any directory", () => {
+    expect(requiresTest("src/project-memory/parser.ts")).toBe(true);
+  });
+
+  it("matches parsers.ts in any directory", () => {
+    expect(requiresTest("src/something/parsers.ts")).toBe(true);
+  });
+
+  it("matches parser.ts at root depth", () => {
+    expect(requiresTest("parser.ts")).toBe(true);
+  });
+
+  it("matches a deeply nested parsers.ts", () => {
+    expect(requiresTest("src/x/y/parsers.ts")).toBe(true);
+  });
+});
+
+describe("requiresTest — negative: paths that do not match any pattern", () => {
+  it("does not match src/agents/planner.ts", () => {
+    expect(requiresTest("src/agents/planner.ts")).toBe(false);
+  });
+
+  it("does not match src/octto/session.ts", () => {
+    expect(requiresTest("src/octto/session.ts")).toBe(false);
+  });
+
+  it("does not match src/hooks/foo.ts", () => {
+    expect(requiresTest("src/hooks/foo.ts")).toBe(false);
+  });
+
+  it("does not match a generic UI display path", () => {
+    expect(requiresTest("src/ui/display.ts")).toBe(false);
+  });
+
+  it("does not match src/index.ts", () => {
+    expect(requiresTest("src/index.ts")).toBe(false);
+  });
+
+  it("does not match a file merely containing 'schema' mid-path (not as basename)", () => {
+    // 'schema-utils/helper.ts' — the word 'schema' is part of a directory segment, not the file name
+    expect(requiresTest("src/agents/schema-utils/helper.ts")).toBe(false);
+  });
+
+  it("does not match a file merely containing 'parser' mid-path (not as basename)", () => {
+    expect(requiresTest("src/agents/parser-helpers/index.ts")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `REQUIRED_TEST_PATHS` and `requiresTest()` so mandatory tests are defined by a small regex policy instead of blanket TDD.
- Update planner/reviewer prompts so `Test: none` is normal for non-required files while required paths still fail closed.
- Add coverage for required-test path matching.

## Verification
- `bun test tests/utils/required-test-paths.test.ts`
- `bun test tests/utils/`
- `bun test tests/agents/planner.test.ts tests/agents/reviewer-prompt.test.ts`
- `bun run check` (1898 pass, 0 fail)

Closes #32