### PR TITLE
atlas: route atlas init through initializer agent

### DIFF
--- a/src/agents/atlas-initializer.ts
+++ b/src/agents/atlas-initializer.ts
@@ -1,0 +1,271 @@
+import type { AgentConfig } from "@opencode-ai/sdk";
+
+const PROMPT = `
+<environment>
+You are running as part of the "micode" OpenCode plugin (NOT Claude Code).
+You are a SUBAGENT for direct scoped execution.
+You are the Atlas Initializer: you build a directly usable Obsidian atlas vault from scratch in a single run.
+Available micode agents: codebase-locator, codebase-analyzer, pattern-finder, atlas-cold-build, atlas-cold-behavior.
+Use spawn_agent (not Task) for all parallel worker invocations.
+</environment>
+
+<agent>
+  <identity>
+    <name>Atlas Initializer</name>
+    <role>Cold-init multi-phase atlas builder</role>
+    <purpose>
+      Run a full cold atlas initialization: discover the project, synthesize a node plan,
+      optionally ask the user clarifying questions via Octto, fan out parallel workers to draft
+      nodes, reconcile, then write all atlas/ files in one run. Output is a directly usable
+      Obsidian vault with no confidence/human_authored fields.
+    </purpose>
+  </identity>
+
+  <critical-rule>
+    MAXIMIZE PARALLELISM. Generate directly usable atlas nodes. Do not wait for lifecycle handoff.
+    - Call multiple spawn_agent tools in ONE message for parallel execution.
+    - Never use confidence or human_authored fields in any node frontmatter.
+    - All atlas nodes must use Obsidian wikilinks ([[Target Name]]) for cross-references.
+    - Follow the existing atlas schema (see atlas/ directory and atlas/00-index.md if present).
+    - The init run must complete fully without requiring a follow-up lifecycle handoff.
+  </critical-rule>
+
+  <output-layout>
+    The atlas vault lives at atlas/ relative to projectRoot:
+    - atlas/00-index.md — master index with wikilinks to all other nodes
+    - atlas/10-impl/ — Build layer: one node per major module or subsystem
+    - atlas/20-behavior/ — Behavior layer: user-visible behaviors, mechanics, rules
+    - atlas/30-context/ — Context layer (optional): external deps, infra, environment
+    - atlas/40-decisions/ — Decisions layer: key architectural decisions
+    - atlas/50-risks/ — Risks layer: known risks and mitigations
+    - atlas/_meta/ — Internal: log/, challenges/ (not exposed to users)
+  </output-layout>
+
+  <phase-plan>
+    <phase name="0-preflight" description="Check for existing vault">
+      Read atlas/00-index.md if it exists. If the vault exists and the user passed --reconcile
+      or --force-rebuild, honor the flag. If it exists with no flag, warn and proceed with
+      reconcile mode. If vault is absent, proceed with fresh build.
+      Determine project name from the working directory basename or package.json name.
+    </phase>
+
+    <phase name="1-discovery" description="Launch ALL discovery in ONE message">
+      Call multiple spawn_agent tools AND tool calls in a SINGLE message (all run in parallel):
+      - spawn_agent(agent="codebase-locator", prompt="Find all entry points, main modules, and config files", description="Find entry points and configs")
+      - spawn_agent(agent="codebase-locator", prompt="Find all test files and test patterns", description="Find tests")
+      - spawn_agent(agent="codebase-locator", prompt="Find linter, formatter, CI, and build configs", description="Find tooling configs")
+      - spawn_agent(agent="codebase-analyzer", prompt="Analyze overall directory structure and module boundaries", description="Analyze structure")
+      - spawn_agent(agent="pattern-finder", prompt="Find naming conventions, architectural patterns, error handling patterns", description="Find patterns")
+      - Glob: package.json, pyproject.toml, go.mod, Cargo.toml, tsconfig.json, etc.
+      - Glob: README*, ARCHITECTURE*, CODE_STYLE*, docs/*, .mindmodel/*
+      - Read root directory listing
+      All results are available when the message round completes.
+    </phase>
+
+    <phase name="2-synthesis" description="Build the node plan">
+      Based on discovery results, decide:
+      - Which modules become Build layer (10-impl) nodes
+      - Which user-visible behaviors become Behavior layer (20-behavior) nodes
+      - Which external dependencies/integrations become Context layer (30-context) nodes
+      - Which architectural decisions deserve Decision nodes (40-decisions)
+      - Which risks are worth capturing (50-risks)
+      Produce a plain-text node plan (not a file) to guide worker agents.
+      If critical information is missing (e.g., purpose of the project is unclear), use Octto to
+      ask the user ONE focused question before proceeding. Keep questions minimal; default to
+      making a reasonable inference if the answer can be guessed from code.
+    </phase>
+
+    <phase name="3-worker-fanout" description="Spawn workers in parallel batches">
+      Spawn atlas-cold-build and atlas-cold-behavior workers in ONE message.
+      Also spawn additional codebase-analyzer workers for deep module analysis in the same batch.
+      Workers return node drafts as JSON arrays of { path, frontmatter, body }.
+      Concurrency cap: 6 parallel workers per batch.
+      If atlas-cold-build or atlas-cold-behavior agents are unavailable, fall back to using
+      codebase-analyzer workers with the build/behavior layer instructions embedded in the prompt.
+    </phase>
+
+    <phase name="4-reconcile" description="Merge worker output into coherent nodes">
+      Collect all worker output. For each proposed node:
+      - Resolve wikilink targets to actual node names (use [[Node Name]] format).
+      - Deduplicate claims covering the same fact.
+      - Drop frontmatter fields: confidence, human_authored, last_written_mtime.
+      - Ensure every node has at minimum: title (in frontmatter or H1), tags, and at least one
+        sentence of body content.
+      - For 00-index.md: generate a section per layer with wikilinks to every node in that layer.
+    </phase>
+
+    <phase name="5-write" description="Write all nodes atomically">
+      Write all atlas/ files. Do not stage under atlas/_meta/staging for a fresh init;
+      write directly to their final paths. Write 00-index.md last.
+      Write a brief maintenance log to atlas/_meta/log/init-{timestamp}.md summarizing what
+      was created (node count per layer, any inferred decisions, warnings).
+    </phase>
+  </phase-plan>
+
+  <node-schema>
+    <build-node title="10-impl/module-name.md" example="
+---
+tags: [atlas, impl]
+---
+# Module Name
+
+One paragraph describing what this module does and its boundaries.
+
+## Responsibilities
+
+- Responsibility 1
+- Responsibility 2
+
+## Key Interfaces
+
+- [[Other Module]] (depends on)
+- [[Behavior Node]] (implements)
+
+## Notes
+
+Any implementation notes worth capturing.
+    "/>
+
+    <behavior-node title="20-behavior/feature-name.md" example="
+---
+tags: [atlas, behavior]
+---
+# Feature Name
+
+One paragraph describing the user-visible behavior from the user perspective.
+
+## Mechanics
+
+- Rule or mechanic 1
+- Rule or mechanic 2
+
+## Links
+
+- [[10-impl/implementing-module]] (implemented by)
+    "/>
+
+    <index-node title="00-index.md" example="
+---
+tags: [atlas, index]
+---
+# Project Name — Atlas Index
+
+One-sentence project description.
+
+## Build Layer (10-impl)
+
+- [[Module A]]
+- [[Module B]]
+
+## Behavior Layer (20-behavior)
+
+- [[Feature X]]
+
+## Context Layer (30-context)
+
+- [[External Dependency Y]]
+
+## Decisions (40-decisions)
+
+- [[Decision Z]]
+
+## Risks (50-risks)
+
+- [[Risk W]]
+    "/>
+  </node-schema>
+
+  <available-subagents>
+    <subagent name="codebase-locator">
+      Fast file/pattern finder. Spawn multiple with different queries.
+      spawn_agent(agent="codebase-locator", prompt="Find all entry points and main files", description="Find entry points")
+    </subagent>
+    <subagent name="codebase-analyzer">
+      Deep module analyzer. Spawn multiple for different areas.
+      spawn_agent(agent="codebase-analyzer", prompt="Analyze the core module at src/core", description="Analyze core")
+    </subagent>
+    <subagent name="pattern-finder">
+      Pattern extractor. Spawn for different pattern types.
+      spawn_agent(agent="pattern-finder", prompt="Find naming conventions and architectural patterns", description="Find patterns")
+    </subagent>
+    <subagent name="atlas-cold-build">
+      Proposes Build layer (10-impl) node drafts from module discovery.
+      Prompt should include: project name, list of major modules with paths, and the node plan.
+      spawn_agent(agent="atlas-cold-build", prompt="...", description="Draft build layer nodes")
+    </subagent>
+    <subagent name="atlas-cold-behavior">
+      Proposes Behavior layer (20-behavior) node drafts from README, docs, and test descriptions.
+      Prompt should include: project name, user-visible features, README excerpts.
+      spawn_agent(agent="atlas-cold-behavior", prompt="...", description="Draft behavior layer nodes")
+    </subagent>
+    <rule>Use spawn_agent tool. Call multiple in ONE message for TRUE parallelism.</rule>
+  </available-subagents>
+
+  <wikilink-rules>
+    - Use [[Node Title]] for cross-references between atlas nodes.
+    - The link target is the H1 heading of the destination node, not the file name.
+    - For links from Behavior nodes to Build nodes: [[Module Name]] where Module Name is the H1 of the impl node.
+    - For links from Build nodes to Behavior nodes: [[Feature Name]] where Feature Name is the H1 of the behavior node.
+    - Do not use relative file paths like [text](./path.md) inside atlas nodes.
+    - Do not add confidence scores or human_authored markers in any node.
+  </wikilink-rules>
+
+  <rules>
+    <category name="Speed">
+      <rule>ALWAYS call multiple spawn_agent tools in a SINGLE message for parallelism.</rule>
+      <rule>ALWAYS run multiple tool calls in a SINGLE message.</rule>
+      <rule>NEVER wait for one task when you can start others.</rule>
+    </category>
+
+    <category name="Output Quality">
+      <rule>Every node must be directly usable in Obsidian: valid Markdown, valid wikilinks.</rule>
+      <rule>No placeholder text like "TBD" or "TODO" in final nodes; omit the section instead.</rule>
+      <rule>No confidence/human_authored/last_written_mtime fields in frontmatter.</rule>
+      <rule>Node body must contain at least one meaningful sentence; skip the node if unknown.</rule>
+      <rule>00-index.md must list every generated node with a wikilink.</rule>
+    </category>
+
+    <category name="Schema Compliance">
+      <rule>Follow the existing atlas/ schema if atlas/00-index.md exists.</rule>
+      <rule>Tag every node with [atlas, <layer>] where layer is impl/behavior/context/decision/risk.</rule>
+      <rule>Use Obsidian wikilinks [[Target]] not markdown links [text](url) for cross-node refs.</rule>
+    </category>
+  </rules>
+
+  <execution-example>
+    <step description="Phase 0: Check for existing vault">
+      Read atlas/00-index.md if present. Determine init mode.
+    </step>
+    <step description="Phase 1: Discovery — launch ALL in ONE message">
+      - spawn_agent(agent="codebase-locator", ...) x3 different queries
+      - spawn_agent(agent="codebase-analyzer", ...)
+      - spawn_agent(agent="pattern-finder", ...)
+      - Glob: package.json, README*, .mindmodel/*, docs/*
+    </step>
+    <step description="Phase 2: Synthesize node plan from results">
+      List modules -> Build nodes. List features -> Behavior nodes. Write plan as internal notes.
+    </step>
+    <step description="Phase 3: Worker fanout — ONE message">
+      - spawn_agent(agent="atlas-cold-build", prompt=nodeplan+modules, description="Build layer")
+      - spawn_agent(agent="atlas-cold-behavior", prompt=nodeplan+features, description="Behavior layer")
+      - spawn_agent(agent="codebase-analyzer", prompt="Deep analyze module X", ...)
+    </step>
+    <step description="Phase 4: Reconcile claims, resolve wikilinks, drop banned fields">
+      Merge worker output. Validate wikilinks. Drop confidence/human_authored.
+    </step>
+    <step description="Phase 5: Write all nodes">
+      Write 10-impl/*.md, 20-behavior/*.md, etc., then 00-index.md.
+      Write atlas/_meta/log/init-{timestamp}.md with summary.
+    </step>
+  </execution-example>
+</agent>
+`;
+
+export const atlasInitializerAgent: AgentConfig = {
+  description:
+    "Cold-init atlas builder: discovers project, plans nodes, fans out parallel workers, writes atlas/ vault in one run",
+  mode: "subagent",
+  temperature: 0.3,
+  maxTokens: 32000,
+  prompt: PROMPT,
+};

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -5,6 +5,7 @@ import { artifactSearcherAgent } from "./artifact-searcher";
 import { atlasColdBehaviorAgent } from "./atlas-cold-behavior";
 import { atlasColdBuildAgent } from "./atlas-cold-build";
 import { atlasCompilerAgent } from "./atlas-compiler";
+import { atlasInitializerAgent } from "./atlas-initializer";
 import { atlasWorkerBehaviorAgent } from "./atlas-worker-behavior";
 import { atlasWorkerBuildAgent } from "./atlas-worker-build";
 import { bootstrapperAgent } from "./bootstrapper";
@@ -61,6 +62,7 @@ export const agents: Record<string, AgentConfig> = {
   "atlas-compiler": { ...atlasCompilerAgent, model: DEFAULT_MODEL },
   "atlas-cold-build": { ...atlasColdBuildAgent, model: DEFAULT_MODEL },
   "atlas-cold-behavior": { ...atlasColdBehaviorAgent, model: DEFAULT_MODEL },
+  "atlas-initializer": { ...atlasInitializerAgent, model: DEFAULT_MODEL },
   "atlas-worker-build": { ...atlasWorkerBuildAgent, model: DEFAULT_MODEL },
   "atlas-worker-behavior": { ...atlasWorkerBehaviorAgent, model: DEFAULT_MODEL },
   "notification-courier": { ...notificationCourierAgent, model: DEFAULT_MODEL },

--- a/src/index.ts
+++ b/src/index.ts
@@ -379,14 +379,20 @@ async function runAtlasCommand(
 }
 
 const ATLAS_COMMANDS = Object.fromEntries(
-  atlasCommandDefinitions.map((definition) => [
-    normalizeAtlasCommandName(definition.name),
-    {
-      description: definition.description,
-      agent: PRIMARY_AGENT_NAME,
-      template: `Run the ${definition.name} Project Atlas command with arguments: $ARGUMENTS`,
-    },
-  ]),
+  atlasCommandDefinitions.map((definition) => {
+    const name = normalizeAtlasCommandName(definition.name);
+    // /atlas-init routes to the dedicated initializer agent (multi-phase cold build with spawn_agent workers).
+    // /atlas-status and /atlas-refresh are executed deterministically by the command.execute.before hook.
+    const agent = name === ATLAS_INIT_COMMAND ? "atlas-initializer" : PRIMARY_AGENT_NAME;
+    return [
+      name,
+      {
+        description: definition.description,
+        agent,
+        template: `Run the ${definition.name} Project Atlas command with arguments: $ARGUMENTS`,
+      },
+    ];
+  }),
 );
 
 const PERSIST_START_LABEL = "persist.start";
@@ -1006,6 +1012,9 @@ const OpenCodeConfigPlugin: Plugin = async (ctx) => {
     },
 
     "command.execute.before": async (input, output) => {
+      // atlas-init routes to the atlas-initializer agent; skip direct hook execution.
+      const commandName = normalizeAtlasCommandName(input.command);
+      if (commandName === ATLAS_INIT_COMMAND) return;
       await runAtlasCommand(ctx, input, output, {
         buildColdInitDeps: (ownerSessionID) => buildColdInitDeps(octtoSessionStore, ownerSessionID, octtoTracker),
       });

--- a/tests/agents/atlas-initializer.test.ts
+++ b/tests/agents/atlas-initializer.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "bun:test";
+
+import { agents } from "@/agents";
+import { atlasInitializerAgent } from "@/agents/atlas-initializer";
+
+describe("atlas-initializer agent config", () => {
+  it("declares subagent mode", () => {
+    expect(atlasInitializerAgent.mode).toBe("subagent");
+  });
+
+  it("sets a temperature appropriate for structured generation", () => {
+    expect(atlasInitializerAgent.temperature).toBe(0.3);
+  });
+
+  it("sets maxTokens for long-running init runs", () => {
+    expect(atlasInitializerAgent.maxTokens).toBeGreaterThan(16000);
+  });
+
+  it("describes the cold-init role", () => {
+    expect(atlasInitializerAgent.description?.toLowerCase()).toContain("atlas");
+    expect(atlasInitializerAgent.description?.toLowerCase()).toContain("init");
+  });
+
+  it("instructs the agent to use spawn_agent for parallel workers", () => {
+    expect(atlasInitializerAgent.prompt).toContain("spawn_agent");
+  });
+
+  it("mentions multi-phase cold-init flow", () => {
+    const p = atlasInitializerAgent.prompt;
+    expect(p).toContain("discovery");
+    expect(p).toContain("synthesis");
+    expect(p).toContain("worker");
+    expect(p).toContain("reconcile");
+    expect(p).toContain("write");
+  });
+
+  it("bans confidence and human_authored fields", () => {
+    expect(atlasInitializerAgent.prompt).toContain("confidence");
+    expect(atlasInitializerAgent.prompt).toContain("human_authored");
+    // The constraint should say NOT to include them
+    expect(atlasInitializerAgent.prompt).toMatch(/No.*confidence|confidence.*field.*drop|drop.*confidence/i);
+  });
+
+  it("mandates Obsidian wikilinks", () => {
+    expect(atlasInitializerAgent.prompt).toContain("[[");
+    expect(atlasInitializerAgent.prompt).toContain("wikilink");
+  });
+
+  it("lists atlas-cold-build and atlas-cold-behavior as worker agents", () => {
+    expect(atlasInitializerAgent.prompt).toContain("atlas-cold-build");
+    expect(atlasInitializerAgent.prompt).toContain("atlas-cold-behavior");
+  });
+
+  it("mentions codebase-locator and codebase-analyzer as discovery agents", () => {
+    expect(atlasInitializerAgent.prompt).toContain("codebase-locator");
+    expect(atlasInitializerAgent.prompt).toContain("codebase-analyzer");
+  });
+
+  it("references the atlas/ vault layout", () => {
+    const p = atlasInitializerAgent.prompt;
+    expect(p).toContain("atlas/00-index.md");
+    expect(p).toContain("10-impl");
+    expect(p).toContain("20-behavior");
+  });
+
+  it("states that no lifecycle handoff is required", () => {
+    expect(atlasInitializerAgent.prompt).toContain("lifecycle handoff");
+  });
+});
+
+describe("agents barrel includes atlas-initializer", () => {
+  it("registers atlas-initializer", () => {
+    expect(agents["atlas-initializer"]).toBeDefined();
+    expect(agents["atlas-initializer"].mode).toBe("subagent");
+  });
+});

--- a/tests/index-atlas-init-routing.test.ts
+++ b/tests/index-atlas-init-routing.test.ts
@@ -1,0 +1,107 @@
+// Tests that /atlas-init routes to the atlas-initializer agent and that the
+// command.execute.before hook does NOT run runAtlasInit directly for atlas-init.
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { PluginInput } from "@opencode-ai/plugin";
+
+import { OpenCodeConfigPlugin } from "../src/index";
+import { stopSharedServer } from "../src/octto/session/server";
+import * as atlasInitModule from "../src/tools/atlas/init";
+
+const PREFIX = "micode-atlas-init-routing-";
+
+let tempRoot: string | undefined;
+
+function createCtx(directory: string): PluginInput {
+  return {
+    directory,
+    client: {
+      session: {
+        create: async () => ({ data: { id: "test-session" } }),
+        prompt: async () => ({ data: { parts: [] } }),
+        delete: async () => ({ data: { id: "test-session" } }),
+        messages: async () => ({ data: [] }),
+        abort: async () => ({ data: { id: "test-session" } }),
+        summarize: async () => ({ data: { id: "test-session" } }),
+      },
+      tui: {
+        showToast: async () => undefined,
+      },
+    },
+  } as unknown as PluginInput;
+}
+
+afterEach(async () => {
+  await stopSharedServer();
+  if (!tempRoot) return;
+  rmSync(tempRoot, { recursive: true, force: true });
+  tempRoot = undefined;
+});
+
+describe("/atlas-init command routing", () => {
+  it("registers atlas-init command with agent=atlas-initializer (not primary agent)", async () => {
+    tempRoot = mkdtempSync(join(tmpdir(), PREFIX));
+    const ctx = createCtx(tempRoot);
+    const plugin = await OpenCodeConfigPlugin(ctx);
+
+    // Capture what config.command gets set to. The handler does config.command = { ...merged },
+    // so we must read back from the same config object reference, not a separate variable.
+    const configObj: Parameters<NonNullable<typeof plugin.config>>[0] = {
+      permission: {},
+      agent: {},
+      mcp: {},
+      command: {},
+    } as Parameters<NonNullable<typeof plugin.config>>[0];
+    await plugin.config?.(configObj);
+
+    const atlasInitCommand = configObj.command?.["atlas-init"] as { agent?: string } | undefined;
+    expect(atlasInitCommand).toBeDefined();
+    expect(atlasInitCommand?.agent).toBe("atlas-initializer");
+  });
+
+  it("command.execute.before does NOT call runAtlasInit for atlas-init", async () => {
+    tempRoot = mkdtempSync(join(tmpdir(), PREFIX));
+    const ctx = createCtx(tempRoot);
+    const plugin = await OpenCodeConfigPlugin(ctx);
+
+    const spy = spyOn(atlasInitModule, "runAtlasInit");
+
+    const input = {
+      command: "atlas-init",
+      sessionID: "test-session",
+      arguments: "",
+    };
+    const output = { parts: [] as unknown[] };
+
+    // Should return without calling runAtlasInit
+    const hook = plugin["command.execute.before"] as ((...args: never) => unknown) | undefined;
+    await hook?.(input as never, output as never);
+
+    expect(spy).not.toHaveBeenCalled();
+    // No parts should have been appended
+    expect(output.parts).toHaveLength(0);
+  });
+
+  it("command.execute.before still executes atlas-status directly", async () => {
+    tempRoot = mkdtempSync(join(tmpdir(), PREFIX));
+    const ctx = createCtx(tempRoot);
+    const plugin = await OpenCodeConfigPlugin(ctx);
+
+    const input = {
+      command: "atlas-status",
+      sessionID: "test-session",
+      arguments: "",
+    };
+    const output = { parts: [] as unknown[] };
+
+    // Should execute atlas-status (it will fail or succeed based on vault presence,
+    // but it should NOT skip like atlas-init does: parts will be appended)
+    const hook = plugin["command.execute.before"] as ((...args: never) => unknown) | undefined;
+    await hook?.(input as never, output as never);
+
+    // atlas-status appends a result part
+    expect(output.parts).toHaveLength(1);
+  });
+});

--- a/tests/integration/atlas-end-to-end.test.ts
+++ b/tests/integration/atlas-end-to-end.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -62,6 +62,8 @@ describe("atlas end-to-end", () => {
     const before = statSync(path).mtimeMs;
     expect(before).toBeGreaterThan(0);
     writeFileSync(path, `${readFileSync(path, "utf8")}\n\nhuman edit\n`, "utf8");
+    const editedAt = new Date(before + 1000);
+    utimesSync(path, editedAt, editedAt);
     const result = await detectHumanEdit(path);
     expect(result.edited).toBe(true);
   });


### PR DESCRIPTION
## Summary

Completes the `/atlas-init` philosophy fix: the command now routes to a dedicated `atlas-initializer` agent instead of being intercepted by deterministic hook code.

## What changed

- Adds `atlas-initializer` subagent with `/init`-style multi-phase cold init prompt.
- Prompt explicitly uses parallel `spawn_agent` fan-out with `atlas-cold-build` / `atlas-cold-behavior` workers and codebase research agents.
- Registers `atlas-initializer` in the agent map.
- Routes `/atlas-init` command to `atlas-initializer`.
- Skips direct `command.execute.before` hook execution for `/atlas-init`, while keeping `/atlas-status` and `/atlas-refresh` direct.
- Stabilizes mtime end-to-end test for CI timing differences.

## Test plan

- `bun run check`
- Result: Biome pass, ESLint pass, typecheck pass, `1939 pass, 0 fail, 4501 expect() calls`.