### PR TITLE
fix(lifecycle): target origin repo during preflight

### DIFF
--- a/src/lifecycle/index.ts
+++ b/src/lifecycle/index.ts
@@ -158,6 +158,7 @@ const GH_VIEW = "view";
 const GH_EDIT = "edit";
 const GH_TITLE_FLAG = "--title";
 const GH_BODY_FLAG = "--body";
+const GH_REPO_FLAG = "--repo";
 const GH_JSON_FLAG = "--json";
 const GH_BODY_FIELD = "body";
 const GH_ENABLE_ISSUES_FLAG = "--enable-issues";
@@ -433,9 +434,14 @@ const saveAndSync = async (context: LifecycleContext, record: LifecycleRecord): 
   return record;
 };
 
-const createIssue = async (runner: LifecycleRunner, input: StartRequestInput, cwd: string): Promise<IssueIdentity> => {
+const createIssue = async (
+  runner: LifecycleRunner,
+  input: StartRequestInput,
+  cwd: string,
+  repoTarget: string,
+): Promise<IssueIdentity> => {
   const created = await runner.gh(
-    [GH_ISSUE, GH_CREATE, GH_TITLE_FLAG, input.summary, GH_BODY_FLAG, renderStartBody(input)],
+    [GH_ISSUE, GH_CREATE, GH_REPO_FLAG, repoTarget, GH_TITLE_FLAG, input.summary, GH_BODY_FLAG, renderStartBody(input)],
     { cwd },
   );
   if (!completed(created)) throw new Error(formatFailure(ISSUE_CREATE_FAILED, created));
@@ -574,7 +580,7 @@ const createStart = (context: LifecycleContext): LifecycleHandle["start"] => {
     const enableNote = await ensureIssuesEnabled(context.runner, preflight, context.cwd);
     if (enableNote) return abortStart(context, request, preflight, enableNote);
 
-    const identity = await createIssue(context.runner, request, context.cwd);
+    const identity = await createIssue(context.runner, request, context.cwd, preflight.nameWithOwner);
     const opened = createRecord(request, context.worktreesRoot, identity, LIFECYCLE_STATES.ISSUE_OPEN);
     const worktreeNote = await createWorktree(context.runner, opened, context.cwd);
     if (worktreeNote) return abortRecord(context, opened, worktreeNote);

--- a/src/lifecycle/pre-flight.ts
+++ b/src/lifecycle/pre-flight.ts
@@ -25,8 +25,12 @@ const EMPTY_OUTPUT = "";
 const GITHUB_REPO_BASE_URL = "https://github.com";
 const GIT_ORIGIN_ARGS = ["remote", "get-url", "origin"] as const;
 const GH_FIELDS = "nameWithOwner,isFork,parent,owner,viewerPermission,hasIssuesEnabled";
-const GH_REPO_ARGS = ["repo", "view", "--json", GH_FIELDS] as const;
 const OWNER_PERMISSIONS: readonly string[] = ["ADMIN", "MAINTAIN", "WRITE"];
+
+// Patterns for common GitHub remote URL forms.
+// Group 1: owner, Group 2: repo (without .git suffix).
+const HTTPS_ORIGIN_PATTERN = /^https:\/\/github\.com\/([^/]+)\/([^/.]+?)(?:\.git)?$/;
+const SSH_ORIGIN_PATTERN = /^(?:ssh:\/\/)?git@github\.com[:/]([^/]+)\/([^/.]+?)(?:\.git)?$/;
 
 interface RepoParent {
   readonly nameWithOwner: string;
@@ -156,16 +160,41 @@ const createResult = (origin: string, view: RepoView): PreFlightResult => {
   };
 };
 
+/**
+ * Parses a GitHub remote URL into "owner/repo" form.
+ * Returns null when the URL does not match any known GitHub remote format,
+ * so callers can fall back to UNKNOWN rather than guessing the target.
+ */
+export const parseOriginTarget = (url: string): string | null => {
+  const https = HTTPS_ORIGIN_PATTERN.exec(url);
+  if (https) return `${https[1]}/${https[2]}`;
+
+  const ssh = SSH_ORIGIN_PATTERN.exec(url);
+  if (ssh) return `${ssh[1]}/${ssh[2]}`;
+
+  return null;
+};
+
+const viewMatchesOrigin = (nameWithOwner: string, target: string): boolean =>
+  nameWithOwner.toLowerCase() === target.toLowerCase();
+
 export async function classifyRepo(runner: LifecycleRunner, cwd: string): Promise<PreFlightResult> {
   const remote = await runner.git(GIT_ORIGIN_ARGS, { cwd });
   if (!completed(remote)) return createUnknown();
 
   const origin = remote.stdout.trim();
-  const inspected = await runner.gh(GH_REPO_ARGS, { cwd });
+  const target = parseOriginTarget(origin);
+  // If we cannot parse the origin into owner/repo, we cannot safely target gh.
+  if (!target) return createUnknown(origin);
+
+  const inspected = await runner.gh(["repo", "view", target, "--json", GH_FIELDS], { cwd });
   if (!completed(inspected)) return createUnknown(origin);
 
   const view = parseRepoView(inspected.stdout);
   if (!view) return createUnknown(origin);
+
+  // Reject silently if gh returned metadata for a different repo (e.g. inferred upstream).
+  if (!viewMatchesOrigin(view.nameWithOwner, target)) return createUnknown(origin);
 
   return createResult(origin, view);
 }

--- a/tests/lifecycle/index.test.ts
+++ b/tests/lifecycle/index.test.ts
@@ -170,6 +170,17 @@ describe("lifecycle handle", () => {
     expect(runner.edits.at(-1)).toContain("state: cleaned");
   });
 
+  it("targets the origin repo explicitly in gh issue create", async () => {
+    const runner = createRunner();
+    const handle = createLifecycleStore({ runner, worktreesRoot, cwd: worktreesRoot, baseDir });
+
+    await handle.start({ summary: SUMMARY, goals: [], constraints: [] });
+
+    const issueCreate = runner.calls.find((call) => call.bin === "gh" && isArgs(call.args, ["issue", "create"]));
+    expect(issueCreate?.args).toContain("--repo");
+    expect(issueCreate?.args).toContain(`${OWNER}/${REPO}`);
+  });
+
   it("opens lifecycle finish PRs against the resolved master branch", async () => {
     const runner = createRunner(createRepoView(), { originHead: MASTER_HEAD });
     const handle = createLifecycleStore({ runner, worktreesRoot, cwd: worktreesRoot, baseDir });

--- a/tests/lifecycle/pre-flight.test.ts
+++ b/tests/lifecycle/pre-flight.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { classifyRepo, REPO_KIND } from "@/lifecycle/pre-flight";
+import { classifyRepo, parseOriginTarget, REPO_KIND } from "@/lifecycle/pre-flight";
 import type { LifecycleRunner, RunResult } from "@/lifecycle/runner";
 
 const CWD = "/workspace/micode";
@@ -9,14 +9,18 @@ const REPO = "Wuxie233/micode";
 const PARENT_OWNER = "vtemian";
 const PARENT_NAME = "micode";
 const PARENT_REPO = `${PARENT_OWNER}/${PARENT_NAME}`;
-const ORIGIN = `git@github.com:${REPO}.git`;
+const ORIGIN_SSH = `git@github.com:${REPO}.git`;
+const ORIGIN_HTTPS = `https://github.com/${REPO}.git`;
+const ORIGIN_HTTPS_NO_GIT = `https://github.com/${REPO}`;
+const ORIGIN_SSH_PROTOCOL = `ssh://git@github.com/${REPO}.git`;
 const PARENT_URL = `https://github.com/${PARENT_REPO}`;
 const OK_EXIT_CODE = 0;
 const FAILURE_EXIT_CODE = 1;
 const EMPTY_OUTPUT = "";
 const GIT_ARGS = ["remote", "get-url", "origin"] as const;
 const GH_FIELDS = "nameWithOwner,isFork,parent,owner,viewerPermission,hasIssuesEnabled";
-const GH_ARGS = ["repo", "view", "--json", GH_FIELDS] as const;
+// The new explicit-target form: repo view <owner/repo> --json <fields>
+const GH_ARGS_WITH_TARGET = ["repo", "view", REPO, "--json", GH_FIELDS] as const;
 const REAL_GH_REPO_VIEW = JSON.stringify({
   hasIssuesEnabled: true,
   isFork: true,
@@ -51,14 +55,14 @@ const createRun = (stdout: string, exitCode = OK_EXIT_CODE): RunResult => ({
   exitCode,
 });
 
-const createRunner = (outputs: RunnerOutputs): FakeRunner => {
+const createRunner = (outputs: RunnerOutputs, origin = ORIGIN_SSH): FakeRunner => {
   const calls: RunnerCall[] = [];
 
   return {
     calls,
     git: async (args, options) => {
       calls.push({ bin: "git", args, cwd: options?.cwd });
-      return outputs.git ?? createRun(`${ORIGIN}\n`);
+      return outputs.git ?? createRun(`${origin}\n`);
     },
     gh: async (args, options) => {
       calls.push({ bin: "gh", args, cwd: options?.cwd });
@@ -81,11 +85,111 @@ const createRepoView = (overrides: Record<string, unknown>): string =>
 const expectCalls = (runner: FakeRunner): void => {
   expect(runner.calls).toEqual([
     { bin: "git", args: GIT_ARGS, cwd: CWD },
-    { bin: "gh", args: GH_ARGS, cwd: CWD },
+    { bin: "gh", args: GH_ARGS_WITH_TARGET, cwd: CWD },
   ]);
 };
 
+describe("parseOriginTarget", () => {
+  it("parses ssh remote with .git suffix", () => {
+    expect(parseOriginTarget("git@github.com:Wuxie233/micode.git")).toBe("Wuxie233/micode");
+  });
+
+  it("parses https remote with .git suffix", () => {
+    expect(parseOriginTarget("https://github.com/Wuxie233/micode.git")).toBe("Wuxie233/micode");
+  });
+
+  it("parses https remote without .git suffix", () => {
+    expect(parseOriginTarget("https://github.com/Wuxie233/micode")).toBe("Wuxie233/micode");
+  });
+
+  it("parses ssh:// protocol remote with .git suffix", () => {
+    expect(parseOriginTarget("ssh://git@github.com/Wuxie233/micode.git")).toBe("Wuxie233/micode");
+  });
+
+  it("returns null for non-github remotes", () => {
+    expect(parseOriginTarget("https://gitlab.com/owner/repo.git")).toBeNull();
+  });
+
+  it("returns null for malformed URLs", () => {
+    expect(parseOriginTarget("not-a-url")).toBeNull();
+    expect(parseOriginTarget("")).toBeNull();
+  });
+});
+
 describe("classifyRepo", () => {
+  it("passes explicit origin target to gh repo view for ssh remote", async () => {
+    const runner = createRunner({
+      gh: createRun(createRepoView({ isFork: true, parent: { name: PARENT_NAME, owner: { login: PARENT_OWNER } } })),
+    });
+
+    await classifyRepo(runner, CWD);
+
+    const ghCall = runner.calls.find((call) => call.bin === "gh");
+    expect(ghCall?.args[2]).toBe(REPO);
+  });
+
+  it("passes explicit origin target to gh repo view for https remote", async () => {
+    const runner = createRunner(
+      {
+        gh: createRun(createRepoView({ isFork: true, parent: { name: PARENT_NAME, owner: { login: PARENT_OWNER } } })),
+      },
+      ORIGIN_HTTPS,
+    );
+
+    await classifyRepo(runner, CWD);
+
+    const ghCall = runner.calls.find((call) => call.bin === "gh");
+    expect(ghCall?.args[2]).toBe(REPO);
+  });
+
+  it("passes explicit origin target to gh repo view for https without .git", async () => {
+    const runner = createRunner({ gh: createRun(createRepoView({ isFork: true, parent: null })) }, ORIGIN_HTTPS_NO_GIT);
+
+    await classifyRepo(runner, CWD);
+
+    const ghCall = runner.calls.find((call) => call.bin === "gh");
+    expect(ghCall?.args[2]).toBe(REPO);
+  });
+
+  it("passes explicit origin target to gh repo view for ssh:// protocol", async () => {
+    const runner = createRunner({ gh: createRun(createRepoView({ isFork: true, parent: null })) }, ORIGIN_SSH_PROTOCOL);
+
+    await classifyRepo(runner, CWD);
+
+    const ghCall = runner.calls.find((call) => call.bin === "gh");
+    expect(ghCall?.args[2]).toBe(REPO);
+  });
+
+  it("returns unknown when gh nameWithOwner does not case-insensitively match origin", async () => {
+    // gh returned metadata for vtemian/micode (upstream) instead of Wuxie233/micode (origin)
+    const runner = createRunner({
+      gh: createRun(
+        createRepoView({
+          nameWithOwner: "vtemian/micode",
+          owner: { login: "vtemian" },
+          viewerPermission: "READ",
+          hasIssuesEnabled: false,
+          isFork: false,
+        }),
+      ),
+    });
+
+    const preflight = await classifyRepo(runner, CWD);
+
+    expect(preflight.kind).toBe(REPO_KIND.UNKNOWN);
+    expect(preflight.nameWithOwner).toBe(EMPTY_OUTPUT);
+  });
+
+  it("returns unknown when origin URL cannot be parsed", async () => {
+    const runner = createRunner({ git: createRun("not-a-github-url\n") }, "not-a-github-url");
+
+    const preflight = await classifyRepo(runner, CWD);
+
+    expect(preflight.kind).toBe(REPO_KIND.UNKNOWN);
+    // Should not have called gh at all since origin is unparseable
+    expect(runner.calls.filter((c) => c.bin === "gh")).toHaveLength(0);
+  });
+
   it("classifies forks when parent uses { name, owner.login } shape", async () => {
     const runner = createRunner({
       gh: createRun(
@@ -100,7 +204,7 @@ describe("classifyRepo", () => {
 
     expect(preflight).toEqual({
       kind: REPO_KIND.FORK,
-      origin: ORIGIN,
+      origin: ORIGIN_SSH,
       nameWithOwner: REPO,
       viewerLogin: OWNER,
       issuesEnabled: true,
@@ -123,7 +227,7 @@ describe("classifyRepo", () => {
 
     expect(preflight).toEqual({
       kind: REPO_KIND.FORK,
-      origin: ORIGIN,
+      origin: ORIGIN_SSH,
       nameWithOwner: REPO,
       viewerLogin: OWNER,
       issuesEnabled: true,
@@ -146,7 +250,7 @@ describe("classifyRepo", () => {
 
     expect(preflight).toEqual({
       kind: REPO_KIND.FORK,
-      origin: ORIGIN,
+      origin: ORIGIN_SSH,
       nameWithOwner: REPO,
       viewerLogin: OWNER,
       issuesEnabled: true,
@@ -166,7 +270,10 @@ describe("classifyRepo", () => {
   });
 
   it("classifies writable originals as own repos", async () => {
-    const runner = createRunner({ gh: createRun(createRepoView({ nameWithOwner: "Wuxie233/tool" })) });
+    const runner = createRunner(
+      { gh: createRun(createRepoView({ nameWithOwner: "Wuxie233/tool" })) },
+      "git@github.com:Wuxie233/tool.git",
+    );
 
     const preflight = await classifyRepo(runner, CWD);
 
@@ -174,32 +281,38 @@ describe("classifyRepo", () => {
     expect(preflight.nameWithOwner).toBe("Wuxie233/tool");
     expect(preflight.viewerLogin).toBe(OWNER);
     expect(preflight.upstreamUrl).toBeNull();
-    expectCalls(runner);
+    // gh should have been called with the tool repo target
+    const ghCall = runner.calls.find((c) => c.bin === "gh");
+    expect(ghCall?.args[2]).toBe("Wuxie233/tool");
   });
 
-  it("classifies read-only originals as upstream repos", async () => {
-    const runner = createRunner({
-      gh: createRun(
-        createRepoView({
-          nameWithOwner: "vtemian/micode",
-          owner: { login: "vtemian" },
-          viewerPermission: "READ",
-          hasIssuesEnabled: false,
-        }),
-      ),
-    });
+  it("classifies read-only originals as upstream repos when viewed for that same repo", async () => {
+    // This scenario: origin IS vtemian/micode (user cloned upstream directly).
+    // gh view returns upstream data that matches origin, so it should classify as UPSTREAM.
+    const runner = createRunner(
+      {
+        gh: createRun(
+          createRepoView({
+            nameWithOwner: "vtemian/micode",
+            owner: { login: "vtemian" },
+            viewerPermission: "READ",
+            hasIssuesEnabled: false,
+          }),
+        ),
+      },
+      "git@github.com:vtemian/micode.git",
+    );
 
     const preflight = await classifyRepo(runner, CWD);
 
     expect(preflight).toEqual({
       kind: REPO_KIND.UPSTREAM,
-      origin: ORIGIN,
+      origin: "git@github.com:vtemian/micode.git",
       nameWithOwner: "vtemian/micode",
       viewerLogin: null,
       issuesEnabled: false,
       upstreamUrl: null,
     });
-    expectCalls(runner);
   });
 
   it("returns unknown when ownership commands fail", async () => {


### PR DESCRIPTION
## Problem

`lifecycle_start_request` was failing with `pre_flight_failed: vtemian/micode` because `gh repo view` without an explicit repo target was inferring the upstream (`vtemian/micode`) instead of the user's fork (`Wuxie233/micode`). This caused the preflight to classify the repo as UPSTREAM and abort, writing a sentinel at `thoughts/lifecycle/9007199254740991.json`.

## Changes

- **`src/lifecycle/pre-flight.ts`**: Added `parseOriginTarget(url)` that robustly parses common GitHub remote URL forms (https with/without .git, git@, ssh://) into `owner/repo`. `classifyRepo` now calls `gh repo view <target>` with the explicit parsed target, and rejects any response where `nameWithOwner` does not case-insensitively match the parsed target (mismatch guard).
- **`src/lifecycle/index.ts`**: `createIssue` now accepts `repoTarget` and passes `--repo <nameWithOwner>` to `gh issue create`, so issue creation is also explicitly targeted at the fork.
- **Tests**: Updated `pre-flight.test.ts` with `parseOriginTarget` unit tests, mismatch guard tests, and multi-URL-form coverage. Added assertion to `index.test.ts` verifying `--repo Wuxie233/micode` appears in `gh issue create` args.

## Safety

- UPSTREAM blocking in `classifyView` is unchanged.
- If the origin URL cannot be parsed (non-GitHub remote), returns UNKNOWN instead of calling `gh` at all.
- All 1952 tests pass (`bun run check` exit 0).