### PR TITLE
feat(project-memory): add identity resolver and maintenance

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,7 @@ import {
   createProjectMemoryForgetTool,
   createProjectMemoryHealthTool,
   createProjectMemoryLookupTool,
+  createProjectMemoryMaintainTool,
   createProjectMemoryPromoteTool,
   createPTYManager,
   createPtyTools,
@@ -806,6 +807,7 @@ const OpenCodeConfigPlugin: Plugin = async (ctx) => {
     ...createProjectMemoryPromoteTool(ctx),
     ...createProjectMemoryHealthTool(ctx),
     ...createProjectMemoryForgetTool(ctx),
+    ...createProjectMemoryMaintainTool(ctx),
   };
   const skillAutopilotEnabled = userConfig?.features?.skillAutopilot === true;
 

--- a/src/lifecycle/index.ts
+++ b/src/lifecycle/index.ts
@@ -1,13 +1,15 @@
-import { readFile } from "node:fs/promises";
-import { isAbsolute, join } from "node:path";
+import { join } from "node:path";
 import * as v from "valibot";
 
 import { type CompletionNotifier, NOTIFICATION_STATUSES, type NotificationStatus } from "@/notifications";
-import { getDefaultStore, type ProjectMemoryStore, type PromoteOutcome, promoteMarkdown } from "@/project-memory";
+import {
+  type ScheduleMaintenanceInput,
+  type ScheduleMaintenanceOutcome,
+  scheduleProjectMemoryMaintenance,
+} from "@/project-memory/maintenance/scheduler";
 import { config } from "@/utils/config";
 import { extractErrorMessage } from "@/utils/errors";
 import { log } from "@/utils/logger";
-import { resolveProjectId } from "@/utils/project-id";
 import { type CommitAndPushInput, commitAndPush } from "./commits";
 import { resolveDefaultBranch } from "./default-branch";
 import { detectBlockedTasks } from "./finish-guards";
@@ -90,6 +92,7 @@ export interface LifecycleStoreInput {
   readonly journal?: JournalStore;
   readonly lease?: LeaseStore;
   readonly notifier?: CompletionNotifier;
+  readonly maintenanceScheduler?: ProjectMemoryMaintenanceScheduler;
   readonly preStageHook?: CommitAndPushInput["preStageHook"];
   readonly prePushHook?: CommitAndPushInput["prePushHook"];
 }
@@ -108,11 +111,14 @@ interface LifecycleContext {
   readonly journal: JournalStore;
   readonly lease: LeaseStore;
   readonly notifier?: CompletionNotifier;
+  readonly maintenanceScheduler: ProjectMemoryMaintenanceScheduler;
   readonly preStageHook?: CommitAndPushInput["preStageHook"];
   readonly prePushHook?: CommitAndPushInput["prePushHook"];
 }
 
-type ProjectMemoryProvider = () => Promise<ProjectMemoryStore>;
+export type ProjectMemoryMaintenanceScheduler = (
+  input: ScheduleMaintenanceInput,
+) => Promise<ScheduleMaintenanceOutcome>;
 
 const OK_EXIT_CODE = 0;
 const ABORTED_ISSUE_NUMBER = Number.MAX_SAFE_INTEGER;
@@ -140,15 +146,10 @@ const PRE_FLIGHT_FAILED = "pre_flight_failed";
 const EXECUTOR_BLOCKED = "executor_blocked";
 const ISSUES_DISABLED_UPSTREAM = "issues_disabled_upstream";
 const GITHUB_REPO_BASE_URL = "https://github.com";
-const MEMORY_PROMOTION_FAILED = "memory_promotion_failed";
-const MEMORY_PROMOTED = "memory_promoted";
-const MEMORY_REJECTED = "memory_rejected";
-const MEMORY_NO_SOURCE = "no_markdown_source";
-const MEMORY_NO_CANDIDATES = "no_candidates";
 const ISSUE_POINTER_PREFIX = "issue/";
-const ISSUE_ENTITY_PREFIX = "issue-";
-const PROJECT_MEMORY_SOURCE_KIND = "lifecycle";
 const RESOLVED_BASE_PREFIX = "resolved-base";
+const PROJECT_MEMORY_TERMINAL_TRIGGER = "lifecycle.finish";
+const OUTCOME_POINTER_PREFIX = "outcome/";
 
 const GH_ISSUE = "issue";
 const GH_REPO = "repo";
@@ -515,68 +516,47 @@ const applyFinishOutcome = (record: LifecycleRecord, outcome: FinishOutcome): Li
   return touch(advanceTo(advanceTo(next, LIFECYCLE_STATES.CLOSED), LIFECYCLE_STATES.CLEANED));
 };
 
-const resolvePointerPath = (cwd: string, pointer: string): string => {
-  if (isAbsolute(pointer)) return pointer;
-  return join(cwd, pointer);
+const isExecutorBlockedOutcome = (outcome: FinishOutcome): boolean =>
+  outcome.note?.startsWith(EXECUTOR_BLOCKED) ?? false;
+
+const shouldScheduleTerminalMaintenance = (outcome: FinishOutcome): boolean => {
+  if (!config.projectMemory.maintenanceEnabled || !config.projectMemory.maintenanceTerminalTriggerEnabled) return false;
+  return outcome.merged || isExecutorBlockedOutcome(outcome);
 };
 
-const readLatestLedger = async (record: LifecycleRecord, cwd: string): Promise<string | null> => {
-  const pointer = record.artifacts[ARTIFACT_KINDS.LEDGER].at(-1);
-  if (!pointer) return null;
-
-  try {
-    const markdown = await readFile(resolvePointerPath(cwd, pointer), "utf8");
-    if (markdown.trim().length > 0) return markdown;
-    return null;
-  } catch {
-    // Ledger pointers can refer to artifacts removed with a worktree; issue body remains the fallback.
-    return null;
-  }
+const artifactPointersForMaintenance = (record: LifecycleRecord): readonly string[] => {
+  const pointers = [`${ISSUE_POINTER_PREFIX}${record.issueNumber}`];
+  pointers.push(record.branch);
+  for (const pointer of Object.values(record.artifacts).flat()) pointers.push(pointer);
+  return pointers;
 };
 
-const readPromotionMarkdown = async (record: LifecycleRecord, context: LifecycleContext): Promise<string | null> => {
-  const ledger = await readLatestLedger(record, context.cwd);
-  if (ledger) return ledger;
-
-  const body = await readIssueBody(context.runner, record.issueNumber, context.cwd);
-  if (body && body.trim().length > 0) return body;
-  return null;
+const outcomePointerForMaintenance = (outcome: FinishOutcome): string => {
+  if (outcome.merged) return `${OUTCOME_POINTER_PREFIX}merged`;
+  if (isExecutorBlockedOutcome(outcome)) return `${OUTCOME_POINTER_PREFIX}${EXECUTOR_BLOCKED}`;
+  return `${OUTCOME_POINTER_PREFIX}not-merged`;
 };
 
-const getRejectionReason = (outcome: PromoteOutcome): string => {
-  if (outcome.refusedReason) return outcome.refusedReason;
-  return outcome.rejected[0]?.reason ?? MEMORY_NO_CANDIDATES;
-};
-
-const formatPromotionNote = (outcome: PromoteOutcome): string => {
-  if (outcome.accepted.length > 0) return `${MEMORY_PROMOTED}: ${outcome.accepted.length} entries`;
-  return `${MEMORY_REJECTED}: ${getRejectionReason(outcome)}`;
-};
-
-const promoteFinishedRecord = async (
+const scheduleTerminalMaintenance = (
+  context: LifecycleContext,
   record: LifecycleRecord,
   outcome: FinishOutcome,
-  context: LifecycleContext,
-  getStore: ProjectMemoryProvider = getDefaultStore,
-): Promise<LifecycleRecord> => {
-  if (!outcome.merged || !config.projectMemory.promoteOnLifecycleFinish) return record;
+): void => {
+  if (!shouldScheduleTerminalMaintenance(outcome)) return;
 
   try {
-    const markdown = await readPromotionMarkdown(record, context);
-    if (!markdown) return appendNote(record, `${MEMORY_REJECTED}: ${MEMORY_NO_SOURCE}`);
-    const store = await getStore();
-    const identity = await resolveProjectId(context.cwd);
-    const promoted = await promoteMarkdown({
-      store,
-      identity,
-      markdown,
-      defaultEntityName: `${ISSUE_ENTITY_PREFIX}${record.issueNumber}`,
-      sourceKind: PROJECT_MEMORY_SOURCE_KIND,
-      pointer: `${ISSUE_POINTER_PREFIX}${record.issueNumber}`,
-    });
-    return appendNote(record, formatPromotionNote(promoted));
+    void context
+      .maintenanceScheduler({
+        reason: "terminal",
+        triggeredBy: PROJECT_MEMORY_TERMINAL_TRIGGER,
+        directory: context.cwd,
+        sourcePointers: [...artifactPointersForMaintenance(record), outcomePointerForMaintenance(outcome)],
+      })
+      .catch((error: unknown) => {
+        log.warn("lifecycle.project-memory-maintenance", `schedule failed: ${extractErrorMessage(error)}`);
+      });
   } catch (error) {
-    return appendNote(record, `${MEMORY_PROMOTION_FAILED}: ${extractErrorMessage(error)}`);
+    log.warn("lifecycle.project-memory-maintenance", `schedule failed: ${extractErrorMessage(error)}`);
   }
 };
 
@@ -679,6 +659,7 @@ const createFinisher = (context: LifecycleContext): LifecycleHandle["finish"] =>
       const note = buildExecutorBlockedNote(blocked);
       const outcome = buildExecutorBlockedOutcome(note);
       const blockedRecord = await saveAndSync(context, applyFinishOutcome(record, outcome));
+      scheduleTerminalMaintenance(context, blockedRecord, outcome);
       await safeNotify(context, NOTIFICATION_STATUSES.BLOCKED, blockedRecord, note);
       return outcome;
     }
@@ -701,8 +682,8 @@ const createFinisher = (context: LifecycleContext): LifecycleHandle["finish"] =>
     });
     const annotated = annotateWithResolvedBranch(finished, resolvedBranch);
     const outcome = await closeMergedIssue(context.runner, issueNumber, annotated, context.cwd);
-    const promoted = await promoteFinishedRecord(merging, outcome, context);
-    const final = await saveAndSync(context, applyFinishOutcome(promoted, outcome));
+    const final = await saveAndSync(context, applyFinishOutcome(merging, outcome));
+    scheduleTerminalMaintenance(context, final, outcome);
     await safeEmit(context, issueNumber, `Finished: merged=${outcome.merged}, prUrl=${outcome.prUrl ?? "(none)"}`);
     if (outcome.merged) {
       await safeNotify(context, NOTIFICATION_STATUSES.COMPLETED, final, `merged: ${outcome.prUrl ?? "(local merge)"}`);
@@ -841,6 +822,7 @@ export function createLifecycleStore(input: LifecycleStoreInput): LifecycleHandl
     journal,
     lease,
     notifier: input.notifier,
+    maintenanceScheduler: input.maintenanceScheduler ?? scheduleProjectMemoryMaintenance,
     preStageHook: input.preStageHook,
     prePushHook: input.prePushHook,
   };

--- a/src/project-memory/identity.ts
+++ b/src/project-memory/identity.ts
@@ -1,0 +1,210 @@
+import { createProjectRegistry, type ProjectRegistry, type ProjectRegistryRecord } from "@/project-memory/registry";
+import { config } from "@/utils/config";
+import type { ProjectIdentity } from "@/utils/project-id";
+import { normalizeProjectOrigin, projectIdForSource, resolveProjectId } from "@/utils/project-id";
+
+type TargetSource = "explicit" | "session" | "lifecycle";
+type ResolutionSource = TargetSource | "registry" | "directory" | "degraded";
+type ResolutionStatus = "resolved" | "degraded" | "ambiguous" | "blocked";
+
+export interface ProjectMemoryTarget {
+  readonly projectId?: string;
+  readonly origin?: string;
+  readonly alias?: string;
+  readonly worktree?: string;
+}
+
+export interface ProjectMemoryIdentityContext {
+  readonly directory: string;
+  readonly explicitTarget?: ProjectMemoryTarget;
+  readonly sessionTarget?: ProjectMemoryTarget;
+  readonly lifecycleTarget?: ProjectMemoryTarget;
+  readonly registry?: ProjectRegistry;
+}
+
+export interface ProjectMemoryIdentityCandidate {
+  readonly projectId: string;
+  readonly origin?: string;
+  readonly aliases?: readonly string[];
+  readonly worktrees?: readonly string[];
+}
+
+export interface ProjectMemoryIdentityResolution {
+  readonly status: ResolutionStatus;
+  readonly source: ResolutionSource;
+  readonly identity?: ProjectIdentity;
+  readonly candidates?: readonly ProjectMemoryIdentityCandidate[];
+  readonly reason?: string;
+}
+
+interface SourceTarget {
+  readonly source: TargetSource;
+  readonly target: ProjectMemoryTarget;
+}
+
+function hasTargetValue(target: ProjectMemoryTarget): boolean {
+  return Boolean(target.projectId ?? target.origin ?? target.alias ?? target.worktree);
+}
+
+function identityForProjectId(projectId: string): ProjectIdentity | null {
+  const trimmed = projectId.trim();
+  if (trimmed.length === 0) return null;
+  return { projectId: trimmed, kind: "origin", source: `project:${trimmed}` };
+}
+
+function identityForOrigin(origin: string): ProjectIdentity | null {
+  const normalized = normalizeProjectOrigin(origin);
+  if (normalized.length === 0) return null;
+  return { projectId: projectIdForSource(normalized), kind: "origin", source: normalized };
+}
+
+function candidateForRecord(record: ProjectRegistryRecord): ProjectMemoryIdentityCandidate {
+  return {
+    projectId: record.projectId,
+    origin: record.origin,
+    aliases: record.aliases,
+    worktrees: record.worktrees,
+  };
+}
+
+function identityForRecord(record: ProjectRegistryRecord): ProjectIdentity {
+  if (record.origin) return { projectId: record.projectId, kind: "origin", source: record.origin };
+  return { projectId: record.projectId, kind: "path", source: record.worktrees[0] ?? `registry:${record.projectId}` };
+}
+
+function resolved(identity: ProjectIdentity, source: ResolutionSource): ProjectMemoryIdentityResolution {
+  return { status: "resolved", source, identity };
+}
+
+function blocked(source: ResolutionSource, reason: string): ProjectMemoryIdentityResolution {
+  return { status: "blocked", source, reason };
+}
+
+function ambiguous(
+  source: ResolutionSource,
+  matches: readonly ProjectRegistryRecord[],
+): ProjectMemoryIdentityResolution {
+  return {
+    status: "ambiguous",
+    source,
+    candidates: matches.map(candidateForRecord),
+    reason: "project identity is ambiguous; specify projectId or a unique alias/origin/worktree",
+  };
+}
+
+function registrySourceFor(source: TargetSource): ResolutionSource {
+  return source === "explicit" ? source : "registry";
+}
+
+function unmatchedExplicitTarget(target: ProjectMemoryTarget): boolean {
+  return Boolean(target.alias ?? target.worktree);
+}
+
+async function registryMatches(
+  registry: ProjectRegistry,
+  target: ProjectMemoryTarget,
+): Promise<readonly ProjectRegistryRecord[]> {
+  if (target.alias) return registry.findByAlias(target.alias);
+  if (target.origin) return registry.findByOrigin(target.origin);
+  if (target.worktree) return registry.findByWorktree(target.worktree);
+  return [];
+}
+
+async function resolveTarget(
+  registry: ProjectRegistry,
+  sourceTarget: SourceTarget,
+): Promise<ProjectMemoryIdentityResolution | null> {
+  const { source, target } = sourceTarget;
+  const byProjectId = target.projectId ? identityForProjectId(target.projectId) : null;
+  if (byProjectId) return resolved(byProjectId, source);
+
+  const byOrigin = target.origin ? identityForOrigin(target.origin) : null;
+  if (byOrigin && !target.alias && !target.worktree) return resolved(byOrigin, source);
+
+  const matches = await registryMatches(registry, target);
+  const registrySource = registrySourceFor(source);
+  if (matches.length === 1) return resolved(identityForRecord(matches[0]), registrySource);
+  if (matches.length > 1) return ambiguous(registrySource, matches);
+  if (source !== "explicit") return null;
+
+  if (unmatchedExplicitTarget(target)) {
+    return blocked(source, "explicit alias/worktree did not match any project registry record");
+  }
+  if (byOrigin) return resolved(byOrigin, source);
+  return null;
+}
+
+function sourceTargets(context: ProjectMemoryIdentityContext): readonly SourceTarget[] {
+  const targets: SourceTarget[] = [];
+  if (context.explicitTarget && hasTargetValue(context.explicitTarget)) {
+    targets.push({ source: "explicit", target: context.explicitTarget });
+  }
+  if (context.sessionTarget && hasTargetValue(context.sessionTarget)) {
+    targets.push({ source: "session", target: context.sessionTarget });
+  }
+  if (context.lifecycleTarget && hasTargetValue(context.lifecycleTarget)) {
+    targets.push({ source: "lifecycle", target: context.lifecycleTarget });
+  }
+  return targets;
+}
+
+async function resolveRegistryDirectory(
+  registry: ProjectRegistry,
+  directory: string,
+): Promise<ProjectMemoryIdentityResolution | null> {
+  const matches = await registry.findByWorktree(directory);
+  if (matches.length === 1) return resolved(identityForRecord(matches[0]), "registry");
+  if (matches.length > 1) return ambiguous("registry", matches);
+  return null;
+}
+
+function directoryResolution(identity: ProjectIdentity): ProjectMemoryIdentityResolution {
+  if (identity.kind === "origin") return resolved(identity, "directory");
+  return {
+    status: "degraded",
+    source: "degraded",
+    identity,
+    reason: "project identity resolved from path only; origin not resolved",
+  };
+}
+
+export async function resolveProjectMemoryIdentity(
+  context: ProjectMemoryIdentityContext,
+): Promise<ProjectMemoryIdentityResolution> {
+  const registry = context.registry ?? createProjectRegistry();
+
+  for (const sourceTarget of sourceTargets(context)) {
+    const resolution = await resolveTarget(registry, sourceTarget);
+    if (resolution) return resolution;
+  }
+
+  const registryResolution = await resolveRegistryDirectory(registry, context.directory);
+  if (registryResolution) return registryResolution;
+
+  return directoryResolution(await resolveProjectId(context.directory));
+}
+
+function assertProjectIdentity(resolution: ProjectMemoryIdentityResolution, operation: string): ProjectIdentity {
+  if (!resolution.identity) {
+    const detail = resolution.reason ? `: ${resolution.reason}` : "";
+    throw new Error(`Project memory ${operation} requires a resolved project identity; ${resolution.status}${detail}`);
+  }
+  if (resolution.status === "ambiguous" || resolution.status === "blocked") {
+    const detail = resolution.reason ? `: ${resolution.reason}` : "";
+    throw new Error(
+      `Project memory ${operation} requires an unambiguous project identity; ${resolution.status}${detail}`,
+    );
+  }
+  if (resolution.identity.kind !== "origin" && config.projectMemory.refuseWritesOnDegradedIdentity) {
+    throw new Error(`Project memory ${operation} refused: degraded path-only project identity is unsafe for writes`);
+  }
+  return resolution.identity;
+}
+
+export function assertWritableProjectIdentity(resolution: ProjectMemoryIdentityResolution): ProjectIdentity {
+  return assertProjectIdentity(resolution, "write");
+}
+
+export function assertMaintenanceProjectIdentity(resolution: ProjectMemoryIdentityResolution): ProjectIdentity {
+  return assertProjectIdentity(resolution, "maintenance");
+}

--- a/src/project-memory/lookup.ts
+++ b/src/project-memory/lookup.ts
@@ -15,12 +15,16 @@ export interface LookupInput {
 }
 
 const ELLIPSIS = "…";
+export const DEFAULT_LOOKUP_STATUS: Status = "active";
 const STATUS_RANK: Record<Status, number> = {
   active: 0,
   tentative: 1,
   hypothesis: 2,
-  superseded: 3,
-  deprecated: 4,
+  stale: 3,
+  superseded: 4,
+  deprecated: 5,
+  archived: 6,
+  tombstoned: 7,
 };
 
 function trimSnippet(summary: string): string {
@@ -65,7 +69,7 @@ export async function lookup(input: LookupInput): Promise<readonly LookupHit[]> 
   const limit = input.limit ?? config.projectMemory.defaultLookupLimit;
   const hits = await input.store.searchEntries(input.identity.projectId, input.query, {
     type: input.type,
-    status: input.status,
+    status: input.status ?? DEFAULT_LOOKUP_STATUS,
     entityId: input.entityId,
     sensitivityCeiling: input.sensitivityCeiling,
     limit,

--- a/src/project-memory/maintenance/classifier.ts
+++ b/src/project-memory/maintenance/classifier.ts
@@ -1,0 +1,223 @@
+import type { MaintenancePlan, MaintenancePlanItem, MaintenanceReason } from "@/project-memory/maintenance/types";
+import type { Entry, Source } from "@/project-memory/types";
+import { detectSecret } from "@/utils/secret-detect";
+
+const MS_PER_DAY = 86_400_000;
+const STALE_DAYS = 90;
+const REVIEW_TYPES = new Set<Entry["type"]>(["decision", "risk"]);
+const LOW_SIGNAL_MISSING_SOURCE_TYPES = new Set<Entry["type"]>(["note", "todo"]);
+
+export const DEFAULT_MAINTENANCE_STALE_AFTER_MS = STALE_DAYS * MS_PER_DAY;
+
+export interface MaintenanceSnapshot {
+  readonly projectId: string;
+  readonly reason: MaintenanceReason;
+  readonly now?: number;
+  readonly staleAfterMs?: number;
+  readonly entries: readonly Entry[];
+  readonly sources: readonly Source[];
+}
+
+function normalizeText(value: string): string {
+  return value.trim().replace(/\s+/g, " ");
+}
+
+function duplicateKey(entry: Entry): string {
+  return [entry.entityId, entry.type, normalizeText(entry.title), normalizeText(entry.summary)].join("\0");
+}
+
+function newerEntryFirst(left: Entry, right: Entry): number {
+  return right.updatedAt - left.updatedAt || right.createdAt - left.createdAt || right.id.localeCompare(left.id);
+}
+
+function duplicateEntryIds(entries: readonly Entry[]): ReadonlySet<string> {
+  const groups = new Map<string, Entry[]>();
+  for (const entry of entries) {
+    const key = duplicateKey(entry);
+    const group = groups.get(key) ?? [];
+    group.push(entry);
+    groups.set(key, group);
+  }
+
+  const duplicateIds = new Set<string>();
+  for (const group of groups.values()) {
+    if (group.length < 2) continue;
+    const [, ...olderEntries] = [...group].sort(newerEntryFirst);
+    for (const entry of olderEntries) duplicateIds.add(entry.id);
+  }
+  return duplicateIds;
+}
+
+function sourceEntryIds(sources: readonly Source[]): ReadonlySet<string> {
+  return new Set(sources.map((source) => source.entryId));
+}
+
+function isOlderThan(entry: Entry, now: number, staleAfterMs: number): boolean {
+  return now - entry.updatedAt > staleAfterMs;
+}
+
+function containsSecret(entry: Entry): boolean {
+  return detectSecret(`${entry.title}\n${entry.summary}`) !== null;
+}
+
+function isAtlasObservation(entry: Entry): boolean {
+  const text = `${entry.title}\n${entry.summary}`.toLowerCase();
+  return text.includes("atlas observation:");
+}
+
+function planSecretDeletion(entry: Entry): MaintenancePlanItem {
+  return {
+    entryId: entry.id,
+    kind: "potential_secret",
+    action: "hard_delete_secret",
+    confidence: "high",
+    reason: "Entry title/summary matched secret detector; value intentionally omitted.",
+    safeByDefault: true,
+  };
+}
+
+function planAtlasReview(entry: Entry): MaintenancePlanItem {
+  return {
+    entryId: entry.id,
+    kind: "stale",
+    action: "needs_review",
+    confidence: "medium",
+    reason: "Atlas observation entries require review instead of automatic mutation.",
+    safeByDefault: false,
+  };
+}
+
+function planDuplicateSupersede(entry: Entry): MaintenancePlanItem {
+  return {
+    entryId: entry.id,
+    kind: "duplicate",
+    action: "supersede",
+    confidence: "high",
+    reason: "Exact duplicate of a newer entry in the same entity/type/title/summary group.",
+    safeByDefault: true,
+  };
+}
+
+function planHistoricalArchive(entry: Entry): MaintenancePlanItem | null {
+  if (entry.status === "deprecated") {
+    return {
+      entryId: entry.id,
+      kind: "deprecated",
+      action: "archive",
+      confidence: "high",
+      reason: "Deprecated entry is older than the maintenance stale threshold.",
+      safeByDefault: true,
+    };
+  }
+
+  if (entry.status === "superseded") {
+    return {
+      entryId: entry.id,
+      kind: "superseded",
+      action: "archive",
+      confidence: "high",
+      reason: "Superseded entry is older than the maintenance stale threshold.",
+      safeByDefault: true,
+    };
+  }
+
+  return null;
+}
+
+function planMissingSource(entry: Entry): MaintenancePlanItem | null {
+  if (LOW_SIGNAL_MISSING_SOURCE_TYPES.has(entry.type)) {
+    return {
+      entryId: entry.id,
+      kind: "missing_source",
+      action: "archive",
+      confidence: "low",
+      reason: "Low-signal note/todo entry has no source pointer.",
+      safeByDefault: true,
+    };
+  }
+
+  if (REVIEW_TYPES.has(entry.type)) {
+    return {
+      entryId: entry.id,
+      kind: "missing_source",
+      action: "needs_review",
+      confidence: "medium",
+      reason: "Decision/risk entry has no source pointer and must not be deleted automatically.",
+      safeByDefault: false,
+    };
+  }
+
+  return {
+    entryId: entry.id,
+    kind: "missing_source",
+    action: "mark_stale",
+    confidence: "low",
+    reason: "Entry has no source pointer; mark stale instead of deleting.",
+    safeByDefault: true,
+  };
+}
+
+function planOldActive(entry: Entry): MaintenancePlanItem | null {
+  if (entry.status !== "active") return null;
+
+  if (REVIEW_TYPES.has(entry.type)) {
+    return {
+      entryId: entry.id,
+      kind: "stale",
+      action: "needs_review",
+      confidence: "medium",
+      reason: "Old active decision/risk needs human review before staling.",
+      safeByDefault: false,
+    };
+  }
+
+  return {
+    entryId: entry.id,
+    kind: "stale",
+    action: "mark_stale",
+    confidence: "medium",
+    reason: "Active entry is older than the maintenance stale threshold.",
+    safeByDefault: true,
+  };
+}
+
+function classifyEntry(
+  entry: Entry,
+  context: {
+    readonly duplicateIds: ReadonlySet<string>;
+    readonly sourceIds: ReadonlySet<string>;
+    readonly now: number;
+    readonly staleAfterMs: number;
+  },
+): MaintenancePlanItem | null {
+  if (containsSecret(entry)) return planSecretDeletion(entry);
+  if (isAtlasObservation(entry)) return planAtlasReview(entry);
+  if (context.duplicateIds.has(entry.id)) return planDuplicateSupersede(entry);
+  if (entry.status === "archived" || entry.status === "tombstoned" || entry.status === "stale") return null;
+
+  const old = isOlderThan(entry, context.now, context.staleAfterMs);
+  if (old) {
+    const historicalArchive = planHistoricalArchive(entry);
+    if (historicalArchive) return historicalArchive;
+  }
+
+  if (!context.sourceIds.has(entry.id)) return planMissingSource(entry);
+  if (old) return planOldActive(entry);
+  return null;
+}
+
+export function classifyMaintenanceSnapshot(snapshot: MaintenanceSnapshot): MaintenancePlan {
+  const now = snapshot.now ?? Date.now();
+  const staleAfterMs = snapshot.staleAfterMs ?? DEFAULT_MAINTENANCE_STALE_AFTER_MS;
+  const duplicateIds = duplicateEntryIds(snapshot.entries);
+  const sourceIds = sourceEntryIds(snapshot.sources);
+  const items = snapshot.entries
+    .map((entry) => classifyEntry(entry, { duplicateIds, sourceIds, now, staleAfterMs }))
+    .filter((item): item is MaintenancePlanItem => item !== null);
+
+  return {
+    projectId: snapshot.projectId,
+    reason: snapshot.reason,
+    items,
+  };
+}

--- a/src/project-memory/maintenance/journal.ts
+++ b/src/project-memory/maintenance/journal.ts
@@ -1,0 +1,121 @@
+import { existsSync } from "node:fs";
+import { appendFile, mkdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { config } from "@/utils/config";
+
+const NEWLINE = "\n";
+const MAX_DETAIL_CHARS = 240;
+const REDACTED_SECRET = "[REDACTED]";
+const CREDENTIAL_PATTERNS: readonly RegExp[] = [
+  /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi,
+  /\b(api[_-]?key|password|secret)\b\s*[:=]\s*[^\s,;"'`{}\]]+/gi,
+  /\bsecret\s+[^\s,;"'`{}\]]+/gi,
+  /\bsk-[A-Za-z0-9_-]{20,}\b/g,
+];
+
+export interface MaintenanceJournalEvent {
+  readonly projectId: string;
+  readonly action: string;
+  readonly at?: number;
+  readonly entityIds?: readonly string[];
+  readonly entryIds?: readonly string[];
+  readonly sourceIds?: readonly string[];
+  readonly reasons?: readonly string[];
+  readonly counts?: Readonly<Record<string, number>>;
+  readonly details?: string;
+  readonly entrySummaries?: readonly string[];
+}
+
+export interface MaintenanceJournalOptions {
+  readonly dir?: string;
+}
+
+export interface ReadMaintenanceJournalOptions extends MaintenanceJournalOptions {
+  readonly limit?: number;
+}
+
+function truncateDetail(value: string): string {
+  return value.length <= MAX_DETAIL_CHARS ? value : value.slice(0, MAX_DETAIL_CHARS);
+}
+
+function redactCredentialLikeSubstrings(value: string): string {
+  return CREDENTIAL_PATTERNS.reduce((redacted, pattern) => redacted.replace(pattern, REDACTED_SECRET), value);
+}
+
+function sanitizeJournalText(value: string): string {
+  return truncateDetail(redactCredentialLikeSubstrings(value));
+}
+
+function sanitizeStringArray(values: readonly string[] | undefined, truncate = false): readonly string[] | undefined {
+  if (values === undefined) return undefined;
+  return values.map((value) => (truncate ? sanitizeJournalText(value) : value));
+}
+
+function sanitizeCounts(
+  counts: Readonly<Record<string, number>> | undefined,
+): Readonly<Record<string, number>> | undefined {
+  if (counts === undefined) return undefined;
+  return Object.fromEntries(Object.entries(counts).filter(([, value]) => Number.isFinite(value)));
+}
+
+function compactEvent(event: MaintenanceJournalEvent): MaintenanceJournalEvent {
+  const compacted: MaintenanceJournalEvent = {
+    projectId: event.projectId,
+    action: event.action,
+    at: event.at,
+    entityIds: sanitizeStringArray(event.entityIds),
+    entryIds: sanitizeStringArray(event.entryIds),
+    sourceIds: sanitizeStringArray(event.sourceIds),
+    reasons: sanitizeStringArray(event.reasons),
+    counts: sanitizeCounts(event.counts),
+    details: event.details === undefined ? undefined : sanitizeJournalText(event.details),
+    entrySummaries: sanitizeStringArray(event.entrySummaries, true),
+  };
+
+  return Object.fromEntries(
+    Object.entries(compacted).filter(([, value]) => value !== undefined),
+  ) as MaintenanceJournalEvent;
+}
+
+function journalDir(options: MaintenanceJournalOptions = {}): string {
+  return options.dir ?? config.projectMemory.maintenanceJournalDir;
+}
+
+export function journalPathFor(projectId: string, date?: Date): string {
+  void date;
+  return join(config.projectMemory.maintenanceJournalDir, `${projectId}.jsonl`);
+}
+
+function journalPathForDir(projectId: string, dir: string): string {
+  return join(dir, `${projectId}.jsonl`);
+}
+
+export async function appendMaintenanceJournal(
+  event: MaintenanceJournalEvent,
+  options: MaintenanceJournalOptions = {},
+): Promise<string> {
+  const dir = journalDir(options);
+  const filePath = journalPathForDir(event.projectId, dir);
+  await mkdir(dir, { recursive: true });
+  await appendFile(filePath, `${JSON.stringify(compactEvent(event))}${NEWLINE}`, "utf8");
+  return filePath;
+}
+
+export async function readMaintenanceJournal(
+  projectId: string,
+  options: ReadMaintenanceJournalOptions = {},
+): Promise<readonly MaintenanceJournalEvent[]> {
+  const filePath = journalPathForDir(projectId, journalDir(options));
+  if (!existsSync(filePath)) return [];
+
+  const content = await readFile(filePath, "utf8");
+  const events = content
+    .split(NEWLINE)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => compactEvent(JSON.parse(line) as MaintenanceJournalEvent));
+
+  if (options.limit === undefined) return events;
+  return events.slice(-Math.max(0, options.limit));
+}

--- a/src/project-memory/maintenance/lock.ts
+++ b/src/project-memory/maintenance/lock.ts
@@ -1,0 +1,52 @@
+const MS_PER_SECOND = 1000;
+const SECONDS_PER_MINUTE = 60;
+const DEFAULT_TTL_MINUTES = 5;
+const DEFAULT_TTL_MS = DEFAULT_TTL_MINUTES * SECONDS_PER_MINUTE * MS_PER_SECOND;
+
+interface LockRecord {
+  readonly token: symbol;
+  readonly expiresAt: number;
+}
+
+export interface MaintenanceLock {
+  readonly projectId: string;
+  release(): Promise<void>;
+}
+
+export interface AcquireMaintenanceLockOptions {
+  readonly ttlMs?: number;
+}
+
+const locks = new Map<string, LockRecord>();
+
+function expiryFrom(now: number, ttlMs: number): number {
+  return now + Math.max(0, ttlMs);
+}
+
+function isActive(record: LockRecord | undefined, now: number): boolean {
+  return record !== undefined && record.expiresAt > now;
+}
+
+export async function acquireMaintenanceLock(
+  projectId: string,
+  options: AcquireMaintenanceLockOptions = {},
+): Promise<MaintenanceLock | null> {
+  const now = Date.now();
+  const current = locks.get(projectId);
+  if (isActive(current, now)) return null;
+
+  const token = Symbol(projectId);
+  locks.set(projectId, {
+    token,
+    expiresAt: expiryFrom(now, options.ttlMs ?? DEFAULT_TTL_MS),
+  });
+
+  return {
+    projectId,
+    async release(): Promise<void> {
+      if (locks.get(projectId)?.token === token) {
+        locks.delete(projectId);
+      }
+    },
+  };
+}

--- a/src/project-memory/maintenance/scheduler.ts
+++ b/src/project-memory/maintenance/scheduler.ts
@@ -1,0 +1,171 @@
+import {
+  assertMaintenanceProjectIdentity,
+  type ProjectMemoryIdentityContext,
+  type ProjectMemoryIdentityResolution,
+  type ProjectMemoryTarget,
+  resolveProjectMemoryIdentity,
+} from "@/project-memory/identity";
+import { appendMaintenanceJournal } from "@/project-memory/maintenance/journal";
+import type { MaintenanceRunInput, MaintenanceRunOutcome } from "@/project-memory/maintenance/types";
+import { config } from "@/utils/config";
+
+type MaintenanceWorker = (input: MaintenanceRunInput) => Promise<MaintenanceRunOutcome>;
+type DeferredWork = () => void;
+
+const DEFAULT_TRIGGER = "project-memory-maintenance-scheduler";
+const SCHEDULER_ERROR_ACTION = "scheduler_error";
+
+export interface ScheduleMaintenanceInput {
+  readonly reason: MaintenanceRunInput["reason"];
+  readonly dryRun?: boolean;
+  readonly triggeredBy?: string;
+  readonly sourcePointers?: readonly string[];
+  readonly directory?: string;
+  readonly explicitTarget?: ProjectMemoryTarget;
+  readonly sessionTarget?: ProjectMemoryTarget;
+  readonly lifecycleTarget?: ProjectMemoryTarget;
+}
+
+export interface ScheduleMaintenanceOutcome {
+  readonly scheduled: boolean;
+  readonly reason: string;
+  readonly projectId?: string;
+  readonly warnings: readonly string[];
+  readonly workerOutcome?: MaintenanceRunOutcome;
+}
+
+export interface ScheduleMaintenanceDeps {
+  readonly resolveIdentity?: (context: ProjectMemoryIdentityContext) => Promise<ProjectMemoryIdentityResolution>;
+  readonly runWorker?: MaintenanceWorker;
+  readonly appendJournal?: typeof appendMaintenanceJournal;
+  readonly defer?: (work: DeferredWork) => void;
+  readonly cwd?: () => string;
+  readonly maintenanceEnabled?: () => boolean;
+  readonly terminalTriggerEnabled?: () => boolean;
+}
+
+interface SchedulerDeps {
+  readonly resolveIdentity: (context: ProjectMemoryIdentityContext) => Promise<ProjectMemoryIdentityResolution>;
+  readonly runWorker: MaintenanceWorker;
+  readonly appendJournal: typeof appendMaintenanceJournal;
+  readonly defer: (work: DeferredWork) => void;
+  readonly cwd: () => string;
+  readonly maintenanceEnabled: () => boolean;
+  readonly terminalTriggerEnabled: () => boolean;
+}
+
+function defaultCwd(): string {
+  return process.cwd();
+}
+
+function defaultDefer(work: DeferredWork): void {
+  setTimeout(work, 0);
+}
+
+async function defaultRunWorker(input: MaintenanceRunInput): Promise<MaintenanceRunOutcome> {
+  const workerModule = (await import(`./${"worker"}`)) as {
+    readonly runProjectMemoryMaintenance?: MaintenanceWorker;
+    readonly executeProjectMemoryMaintenance?: MaintenanceWorker;
+  };
+  const worker = workerModule.runProjectMemoryMaintenance ?? workerModule.executeProjectMemoryMaintenance;
+  if (!worker) throw new Error("Project memory maintenance worker is unavailable");
+  return worker(input);
+}
+
+function warningForError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function blocked(reason: string, projectId?: string): ScheduleMaintenanceOutcome {
+  return { scheduled: false, reason: `blocked: ${reason}`, projectId, warnings: [reason] };
+}
+
+function identityBlockReason(resolution: ProjectMemoryIdentityResolution, error: unknown): string {
+  if (resolution.status === "ambiguous" || resolution.status === "blocked" || resolution.status === "degraded") {
+    return resolution.reason ?? `project identity is ${resolution.status}`;
+  }
+  return warningForError(error);
+}
+
+function workerInput(input: ScheduleMaintenanceInput, projectId: string): MaintenanceRunInput {
+  return {
+    projectId,
+    reason: input.reason,
+    dryRun: input.dryRun === true,
+    triggeredBy: input.triggeredBy ?? DEFAULT_TRIGGER,
+    sourcePointers: input.sourcePointers ? [...input.sourcePointers] : undefined,
+  };
+}
+
+function schedulerDeps(deps: ScheduleMaintenanceDeps): SchedulerDeps {
+  return {
+    resolveIdentity: deps.resolveIdentity ?? resolveProjectMemoryIdentity,
+    runWorker: deps.runWorker ?? defaultRunWorker,
+    appendJournal: deps.appendJournal ?? appendMaintenanceJournal,
+    defer: deps.defer ?? defaultDefer,
+    cwd: deps.cwd ?? defaultCwd,
+    maintenanceEnabled: deps.maintenanceEnabled ?? (() => config.projectMemory.maintenanceEnabled),
+    terminalTriggerEnabled:
+      deps.terminalTriggerEnabled ?? (() => config.projectMemory.maintenanceTerminalTriggerEnabled),
+  };
+}
+
+async function recordDetachedWorkerError(
+  projectId: string,
+  error: unknown,
+  appendJournal: typeof appendMaintenanceJournal,
+): Promise<void> {
+  await appendJournal({
+    projectId,
+    action: SCHEDULER_ERROR_ACTION,
+    details: warningForError(error),
+    counts: { warnings: 1 },
+  });
+}
+
+export function createProjectMemoryMaintenanceScheduler(deps: ScheduleMaintenanceDeps = {}) {
+  const runtime = schedulerDeps(deps);
+
+  return async function schedule(input: ScheduleMaintenanceInput): Promise<ScheduleMaintenanceOutcome> {
+    if (!runtime.maintenanceEnabled()) return { scheduled: false, reason: "disabled", warnings: [] };
+    if (input.reason === "terminal" && !runtime.terminalTriggerEnabled()) {
+      return { scheduled: false, reason: "terminal-trigger-disabled", warnings: [] };
+    }
+
+    const resolution = await runtime.resolveIdentity({
+      directory: input.directory ?? runtime.cwd(),
+      explicitTarget: input.explicitTarget,
+      sessionTarget: input.sessionTarget,
+      lifecycleTarget: input.lifecycleTarget,
+    });
+
+    let projectId: string;
+    try {
+      projectId = assertMaintenanceProjectIdentity(resolution).projectId;
+    } catch (error) {
+      return blocked(identityBlockReason(resolution, error), resolution.identity?.projectId);
+    }
+
+    const runInput = workerInput(input, projectId);
+    if (input.dryRun === true) {
+      const workerOutcome = await runtime.runWorker(runInput);
+      return {
+        scheduled: false,
+        reason: "dry-run-executed",
+        projectId,
+        warnings: workerOutcome.warnings,
+        workerOutcome,
+      };
+    }
+
+    runtime.defer(() => {
+      void runtime.runWorker(runInput).catch((error: unknown) => {
+        void recordDetachedWorkerError(projectId, error, runtime.appendJournal).catch(() => undefined);
+      });
+    });
+
+    return { scheduled: true, reason: "scheduled", projectId, warnings: [] };
+  };
+}
+
+export const scheduleProjectMemoryMaintenance = createProjectMemoryMaintenanceScheduler();

--- a/src/project-memory/maintenance/types.ts
+++ b/src/project-memory/maintenance/types.ts
@@ -1,0 +1,89 @@
+import * as v from "valibot";
+
+export const MaintenanceReasonValues = ["manual", "terminal", "scheduled", "dry-run"] as const;
+
+export const MaintenanceCandidateKindValues = [
+  "duplicate",
+  "missing_source",
+  "stale",
+  "superseded",
+  "deprecated",
+  "low_signal",
+  "potential_secret",
+  "orphan",
+] as const;
+
+export const MaintenanceActionKindValues = [
+  "archive",
+  "tombstone",
+  "supersede",
+  "mark_stale",
+  "deduplicate",
+  "refine_summary",
+  "hard_delete_secret",
+  "needs_review",
+  "skip",
+] as const;
+
+export const MaintenanceConfidenceValues = ["low", "medium", "high"] as const;
+
+export type MaintenanceReason = (typeof MaintenanceReasonValues)[number];
+export type MaintenanceCandidateKind = (typeof MaintenanceCandidateKindValues)[number];
+export type MaintenanceActionKind = (typeof MaintenanceActionKindValues)[number];
+export type MaintenanceConfidence = (typeof MaintenanceConfidenceValues)[number];
+
+export const MaintenanceReasonSchema = v.picklist(MaintenanceReasonValues);
+export const MaintenanceCandidateKindSchema = v.picklist(MaintenanceCandidateKindValues);
+export const MaintenanceActionKindSchema = v.picklist(MaintenanceActionKindValues);
+export const MaintenanceConfidenceSchema = v.picklist(MaintenanceConfidenceValues);
+
+export const MaintenancePlanItemSchema = v.object({
+  entryId: v.string(),
+  kind: MaintenanceCandidateKindSchema,
+  action: MaintenanceActionKindSchema,
+  confidence: MaintenanceConfidenceSchema,
+  reason: v.string(),
+  safeByDefault: v.boolean(),
+});
+
+export const MaintenancePlanSchema = v.object({
+  projectId: v.string(),
+  reason: MaintenanceReasonSchema,
+  items: v.array(MaintenancePlanItemSchema),
+  warnings: v.optional(v.array(v.string())),
+});
+
+export const MaintenanceRunInputSchema = v.object({
+  projectId: v.string(),
+  reason: MaintenanceReasonSchema,
+  dryRun: v.boolean(),
+  triggeredBy: v.string(),
+  sourcePointers: v.optional(v.array(v.string())),
+});
+
+export const MaintenanceRunOutcomeSchema = v.object({
+  applied: v.number(),
+  skipped: v.number(),
+  blocked: v.number(),
+  warnings: v.array(v.string()),
+  journalPath: v.string(),
+});
+
+export const MaintenanceJournalEventSchema = v.object({
+  projectId: v.string(),
+  action: MaintenanceActionKindSchema,
+  at: v.optional(v.number()),
+  entityIds: v.optional(v.array(v.string())),
+  entryIds: v.optional(v.array(v.string())),
+  sourceIds: v.optional(v.array(v.string())),
+  reasons: v.optional(v.array(MaintenanceCandidateKindSchema)),
+  counts: v.optional(v.record(v.string(), v.number())),
+  details: v.optional(v.string()),
+  entrySummaries: v.optional(v.array(v.string())),
+});
+
+export type MaintenancePlanItem = v.InferOutput<typeof MaintenancePlanItemSchema>;
+export type MaintenancePlan = v.InferOutput<typeof MaintenancePlanSchema>;
+export type MaintenanceRunInput = v.InferOutput<typeof MaintenanceRunInputSchema>;
+export type MaintenanceRunOutcome = v.InferOutput<typeof MaintenanceRunOutcomeSchema>;
+export type MaintenanceJournalEvent = v.InferOutput<typeof MaintenanceJournalEventSchema>;

--- a/src/project-memory/maintenance/worker.ts
+++ b/src/project-memory/maintenance/worker.ts
@@ -1,0 +1,305 @@
+import { classifyMaintenanceSnapshot } from "@/project-memory/maintenance/classifier";
+import { appendMaintenanceJournal } from "@/project-memory/maintenance/journal";
+import { acquireMaintenanceLock } from "@/project-memory/maintenance/lock";
+import type {
+  MaintenanceActionKind,
+  MaintenancePlan,
+  MaintenancePlanItem,
+  MaintenanceRunInput,
+  MaintenanceRunOutcome,
+} from "@/project-memory/maintenance/types";
+import type { ProjectMemoryStore } from "@/project-memory/store";
+import type { Status } from "@/project-memory/types";
+import { config } from "@/utils/config";
+import type { ProjectIdentity } from "@/utils/project-id";
+
+export interface BuildMaintenancePlanInput {
+  readonly store: ProjectMemoryStore;
+  readonly identity: ProjectIdentity;
+  readonly reason?: MaintenanceRunInput["reason"];
+  readonly now?: number;
+  readonly snapshotLimit?: number;
+}
+
+export interface MaintenanceRunOptions {
+  readonly now?: number;
+  readonly journalDir?: string;
+  readonly snapshotLimit?: number;
+}
+
+export type MaintenanceRunInputWithDeps = MaintenanceRunInput &
+  MaintenanceRunOptions & {
+    readonly store: ProjectMemoryStore;
+    readonly identity: ProjectIdentity;
+  };
+
+export interface MaintenanceRunOutcomeWithPlan extends MaintenanceRunOutcome {
+  readonly plan: MaintenancePlan;
+}
+
+interface ApplyCounts extends Record<string, number> {
+  applied: number;
+  skipped: number;
+  blocked: number;
+}
+
+const STATUS_BY_ACTION: Partial<Record<MaintenanceActionKind, Status>> = {
+  archive: "archived",
+  tombstone: "tombstoned",
+  supersede: "superseded",
+  deduplicate: "superseded",
+  mark_stale: "stale",
+};
+
+function projectIdFor(identity: ProjectIdentity): string {
+  return identity.projectId;
+}
+
+function snapshotLimit(inputLimit?: number): number {
+  return inputLimit ?? config.projectMemory.maintenanceSnapshotLimit;
+}
+
+function emptyPlan(
+  projectId: string,
+  reason: MaintenanceRunInput["reason"],
+  warnings?: readonly string[],
+): MaintenancePlan {
+  return {
+    projectId,
+    reason,
+    items: [],
+    warnings: warnings === undefined ? undefined : [...warnings],
+  };
+}
+
+function warningOutcome(
+  projectId: string,
+  reason: MaintenanceRunInput["reason"],
+  warning: string,
+  journalPath: string,
+): MaintenanceRunOutcomeWithPlan {
+  return {
+    applied: 0,
+    skipped: 1,
+    blocked: 0,
+    warnings: [warning],
+    journalPath,
+    plan: emptyPlan(projectId, reason, [warning]),
+  };
+}
+
+function failureOutcome(
+  projectId: string,
+  reason: MaintenanceRunInput["reason"],
+  warning: string,
+  journalPath: string,
+): MaintenanceRunOutcomeWithPlan {
+  return {
+    applied: 0,
+    skipped: 0,
+    blocked: 1,
+    warnings: [warning],
+    journalPath,
+    plan: emptyPlan(projectId, reason, [warning]),
+  };
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+function isBlockingItem(item: MaintenancePlanItem): boolean {
+  return item.action === "needs_review" || item.action === "skip" || !item.safeByDefault;
+}
+
+async function appendJournalForItem(
+  projectId: string,
+  item: MaintenancePlanItem,
+  now: number,
+  journalDir?: string,
+): Promise<string> {
+  return appendMaintenanceJournal(
+    {
+      projectId,
+      action: item.action,
+      at: now,
+      entryIds: [item.entryId],
+      reasons: [item.kind],
+      details: item.reason,
+    },
+    { dir: journalDir },
+  );
+}
+
+async function appendSummaryJournal(
+  projectId: string,
+  action: MaintenanceActionKind,
+  counts: ApplyCounts & { readonly planned: number },
+  now: number,
+  journalDir?: string,
+): Promise<string> {
+  return appendMaintenanceJournal(
+    {
+      projectId,
+      action,
+      at: now,
+      counts,
+    },
+    { dir: journalDir },
+  );
+}
+
+async function appendFailureJournal(
+  projectId: string,
+  warning: string,
+  now: number,
+  journalDir?: string,
+): Promise<string> {
+  return appendMaintenanceJournal(
+    {
+      projectId,
+      action: "needs_review",
+      at: now,
+      counts: { blocked: 1 },
+      details: warning,
+    },
+    { dir: journalDir },
+  );
+}
+
+async function applyPlanItem(
+  store: ProjectMemoryStore,
+  projectId: string,
+  item: MaintenancePlanItem,
+  now: number,
+): Promise<"applied" | "skipped" | "blocked"> {
+  if (isBlockingItem(item)) return item.action === "skip" ? "skipped" : "blocked";
+
+  if (item.action === "hard_delete_secret") {
+    await store.forgetEntry(projectId, item.entryId);
+    return "applied";
+  }
+
+  const status = STATUS_BY_ACTION[item.action];
+  if (!status) return "skipped";
+
+  await store.updateEntryStatus(projectId, item.entryId, status, now);
+  return "applied";
+}
+
+function increment(counts: ApplyCounts, result: "applied" | "skipped" | "blocked"): void {
+  counts[result] += 1;
+}
+
+async function skippedLockOutcome(
+  projectId: string,
+  reason: MaintenanceRunInput["reason"],
+  now: number,
+  journalDir?: string,
+): Promise<MaintenanceRunOutcomeWithPlan> {
+  const warning = "project memory maintenance skipped: lock already held";
+  const journalPath = await appendSummaryJournal(
+    projectId,
+    "skip",
+    { planned: 0, applied: 0, skipped: 1, blocked: 0 },
+    now,
+    journalDir,
+  );
+  return warningOutcome(projectId, reason, warning, journalPath);
+}
+
+async function dryRunOutcome(
+  projectId: string,
+  plan: MaintenancePlan,
+  now: number,
+  journalDir?: string,
+): Promise<MaintenanceRunOutcomeWithPlan> {
+  const journalPath = await appendSummaryJournal(
+    projectId,
+    "skip",
+    { planned: plan.items.length, applied: 0, skipped: plan.items.length, blocked: 0 },
+    now,
+    journalDir,
+  );
+  return { applied: 0, skipped: plan.items.length, blocked: 0, warnings: plan.warnings ?? [], journalPath, plan };
+}
+
+async function applyPlan(
+  input: MaintenanceRunInputWithDeps,
+  projectId: string,
+  plan: MaintenancePlan,
+  now: number,
+): Promise<MaintenanceRunOutcomeWithPlan> {
+  const counts: ApplyCounts = { applied: 0, skipped: 0, blocked: 0 };
+  let journalPath = "";
+
+  if (plan.items.length === 0) {
+    journalPath = await appendSummaryJournal(projectId, "skip", { planned: 0, ...counts }, now, input.journalDir);
+  }
+
+  for (const item of plan.items) {
+    const result = await applyPlanItem(input.store, projectId, item, now);
+    increment(counts, result);
+    journalPath = await appendJournalForItem(projectId, item, now, input.journalDir);
+  }
+
+  return { ...counts, warnings: plan.warnings ?? [], journalPath, plan };
+}
+
+async function runMaintenanceWithLock(
+  input: MaintenanceRunInputWithDeps,
+  projectId: string,
+  reason: MaintenanceRunInput["reason"],
+  now: number,
+): Promise<MaintenanceRunOutcomeWithPlan> {
+  const plan = await buildMaintenancePlan({
+    store: input.store,
+    identity: input.identity,
+    reason,
+    now,
+    snapshotLimit: input.snapshotLimit,
+  });
+
+  if (input.dryRun) return dryRunOutcome(projectId, plan, now, input.journalDir);
+  return applyPlan(input, projectId, plan, now);
+}
+
+export async function buildMaintenancePlan(input: BuildMaintenancePlanInput): Promise<MaintenancePlan> {
+  const projectId = projectIdFor(input.identity);
+  const limit = snapshotLimit(input.snapshotLimit);
+  const [entries, sources] = await Promise.all([
+    input.store.listEntries(projectId, { limit }),
+    input.store.listSources(projectId, { limit }),
+    input.store.listEntities(projectId, { limit }),
+  ]);
+
+  return classifyMaintenanceSnapshot({
+    projectId,
+    reason: input.reason ?? "scheduled",
+    now: input.now,
+    entries,
+    sources,
+  });
+}
+
+export async function runProjectMemoryMaintenance(
+  input: MaintenanceRunInputWithDeps,
+): Promise<MaintenanceRunOutcomeWithPlan> {
+  const projectId = projectIdFor(input.identity);
+  const reason = input.reason;
+  const now = input.now ?? Date.now();
+  const lock = await acquireMaintenanceLock(projectId, { ttlMs: config.projectMemory.maintenanceLockTtlMs });
+
+  if (!lock) return skippedLockOutcome(projectId, reason, now, input.journalDir);
+
+  try {
+    return await runMaintenanceWithLock(input, projectId, reason, now);
+  } catch (error) {
+    const warning = `project memory maintenance failed: ${errorMessage(error)}`;
+    const journalPath = await appendFailureJournal(projectId, warning, now, input.journalDir);
+    return failureOutcome(projectId, reason, warning, journalPath);
+  } finally {
+    await lock.release();
+  }
+}

--- a/src/project-memory/registry.ts
+++ b/src/project-memory/registry.ts
@@ -1,0 +1,122 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+import { config } from "@/utils/config";
+import { normalizeProjectOrigin } from "@/utils/project-id";
+
+const REGISTRY_VERSION = 1;
+const JSON_INDENT = 2;
+
+export interface ProjectRegistryRecord {
+  readonly projectId: string;
+  readonly origin?: string;
+  readonly aliases: readonly string[];
+  readonly worktrees: readonly string[];
+  readonly updatedAt: number;
+}
+
+export interface ProjectRegistry {
+  load(): Promise<readonly ProjectRegistryRecord[]>;
+  upsert(record: ProjectRegistryRecord): Promise<void>;
+  findByAlias(alias: string): Promise<readonly ProjectRegistryRecord[]>;
+  findByOrigin(origin: string): Promise<readonly ProjectRegistryRecord[]>;
+  findByWorktree(path: string): Promise<readonly ProjectRegistryRecord[]>;
+}
+
+interface RegistryFile {
+  readonly version: number;
+  readonly records: readonly ProjectRegistryRecord[];
+}
+
+function stringArray(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function registryRecordFromUnknown(value: unknown): ProjectRegistryRecord | null {
+  if (typeof value !== "object" || value === null) return null;
+  const record = value as Record<string, unknown>;
+  if (typeof record.projectId !== "string" || typeof record.updatedAt !== "number") return null;
+
+  return normalizeRegistryRecord({
+    projectId: record.projectId,
+    origin: typeof record.origin === "string" ? record.origin : undefined,
+    aliases: stringArray(record.aliases),
+    worktrees: stringArray(record.worktrees),
+    updatedAt: record.updatedAt,
+  });
+}
+
+export function normalizeRegistryRecord(input: ProjectRegistryRecord): ProjectRegistryRecord {
+  return {
+    projectId: input.projectId,
+    origin: input.origin ? normalizeProjectOrigin(input.origin) : undefined,
+    aliases: normalizeAliases(input.aliases),
+    worktrees: normalizeWorktrees(input.worktrees),
+    updatedAt: input.updatedAt,
+  };
+}
+
+function normalizeAliases(aliases: readonly string[]): readonly string[] {
+  return unique(aliases.map((alias) => alias.trim().toLowerCase()).filter((alias) => alias.length > 0));
+}
+
+function normalizeWorktrees(worktrees: readonly string[]): readonly string[] {
+  return unique(worktrees.map((worktree) => resolve(worktree)));
+}
+
+function unique(values: readonly string[]): readonly string[] {
+  return [...new Set(values)];
+}
+
+function parseRegistryFile(text: string): readonly ProjectRegistryRecord[] {
+  const parsed = JSON.parse(text) as Partial<RegistryFile>;
+  if (parsed.version !== REGISTRY_VERSION || !Array.isArray(parsed.records)) return [];
+  return parsed.records
+    .map((record: unknown) => registryRecordFromUnknown(record))
+    .filter((record): record is ProjectRegistryRecord => record !== null);
+}
+
+function writeRegistryFile(filePath: string, records: readonly ProjectRegistryRecord[]): void {
+  mkdirSync(dirname(filePath), { recursive: true });
+  const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  const payload: RegistryFile = { version: REGISTRY_VERSION, records };
+  writeFileSync(tempPath, `${JSON.stringify(payload, null, JSON_INDENT)}\n`, "utf8");
+  renameSync(tempPath, filePath);
+}
+
+export function createProjectRegistry(options: { readonly filePath?: string } = {}): ProjectRegistry {
+  const filePath = options.filePath ?? config.projectMemory.registryFile;
+
+  async function load(): Promise<readonly ProjectRegistryRecord[]> {
+    if (!existsSync(filePath)) return [];
+    return parseRegistryFile(readFileSync(filePath, "utf8"));
+  }
+
+  return {
+    load,
+
+    async upsert(record: ProjectRegistryRecord): Promise<void> {
+      const normalized = normalizeRegistryRecord(record);
+      const records = await load();
+      const next = [...records.filter((current) => current.projectId !== normalized.projectId), normalized];
+      writeRegistryFile(filePath, next);
+    },
+
+    async findByAlias(alias: string): Promise<readonly ProjectRegistryRecord[]> {
+      const normalized = alias.trim().toLowerCase();
+      if (normalized.length === 0) return [];
+      return (await load()).filter((record) => record.aliases.includes(normalized));
+    },
+
+    async findByOrigin(origin: string): Promise<readonly ProjectRegistryRecord[]> {
+      const normalized = normalizeProjectOrigin(origin);
+      return (await load()).filter((record) => record.origin === normalized);
+    },
+
+    async findByWorktree(path: string): Promise<readonly ProjectRegistryRecord[]> {
+      const normalized = resolve(path);
+      return (await load()).filter((record) => record.worktrees.includes(normalized));
+    },
+  };
+}

--- a/src/project-memory/store.ts
+++ b/src/project-memory/store.ts
@@ -80,7 +80,11 @@ const EMPTY_STATUS_COUNTS: Record<Status, number> = {
   tentative: 0,
   hypothesis: 0,
   deprecated: 0,
+  archived: 0,
+  tombstoned: 0,
+  stale: 0,
 };
+const MAINTENANCE_SNAPSHOT_LIMIT = config.projectMemory.maintenanceSnapshotLimit;
 const SENSITIVITY_RANK: Record<Sensitivity, number> = {
   public: 0,
   internal: 1,
@@ -115,6 +119,14 @@ export interface ProjectMemoryStore {
   loadEntry(projectId: string, id: string): Promise<Entry | null>;
   loadSourcesForEntry(projectId: string, entryId: string): Promise<readonly Source[]>;
   searchEntries(projectId: string, query: string, options?: SearchEntriesOptions): Promise<readonly SearchHit[]>;
+  listEntries(
+    projectId: string,
+    options?: { readonly status?: Status; readonly limit?: number },
+  ): Promise<readonly Entry[]>;
+  listEntities(projectId: string, options?: { readonly limit?: number }): Promise<readonly Entity[]>;
+  listSources(projectId: string, options?: { readonly limit?: number }): Promise<readonly Source[]>;
+  updateEntryStatus(projectId: string, entryId: string, status: Status, updatedAt?: number): Promise<void>;
+  updateEntrySummary(projectId: string, entryId: string, summary: string, updatedAt?: number): Promise<void>;
   countEntities(projectId: string): Promise<number>;
   countEntries(projectId: string): Promise<number>;
   countEntriesByStatus(projectId: string): Promise<Record<Status, number>>;
@@ -430,6 +442,91 @@ function searchEntriesInDb(db: Database, projectId: string, query: string, optio
   return rows.map((row) => ({ entry: rowToEntry(row), score: -row.rank }));
 }
 
+function listEntriesInDb(
+  db: Database,
+  projectId: string,
+  options: { readonly status?: Status; readonly limit?: number },
+): Entry[] {
+  return db
+    .query<EntryRow, [string, Status | null, Status | null, number]>(
+      `SELECT * FROM entries
+       WHERE project_id = ?
+         AND (? IS NULL OR status = ?)
+       ORDER BY updated_at DESC, id ASC
+       LIMIT ?`,
+    )
+    .all(projectId, options.status ?? null, options.status ?? null, options.limit ?? MAINTENANCE_SNAPSHOT_LIMIT)
+    .map(rowToEntry);
+}
+
+function listEntitiesInDb(db: Database, projectId: string, options: { readonly limit?: number }): Entity[] {
+  return db
+    .query<EntityRow, [string, number]>(
+      `SELECT * FROM entities
+       WHERE project_id = ?
+       ORDER BY updated_at DESC, id ASC
+       LIMIT ?`,
+    )
+    .all(projectId, options.limit ?? MAINTENANCE_SNAPSHOT_LIMIT)
+    .map(rowToEntity);
+}
+
+function listSourcesInDb(db: Database, projectId: string, options: { readonly limit?: number }): Source[] {
+  return db
+    .query<SourceRow, [string, number]>(
+      `SELECT * FROM sources
+       WHERE project_id = ?
+       ORDER BY created_at DESC, id ASC
+       LIMIT ?`,
+    )
+    .all(projectId, options.limit ?? MAINTENANCE_SNAPSHOT_LIMIT)
+    .map(rowToSource);
+}
+
+function updateEntryInDb(
+  db: Database,
+  projectId: string,
+  entryId: string,
+  update: (entry: Entry, updatedAt: number) => Entry,
+  updatedAt = Date.now(),
+): void {
+  const current = loadEntryFromDb(db, projectId, entryId);
+  if (!current) return;
+  upsertEntryInDb(db, update(current, updatedAt));
+}
+
+function updateEntryStatusInDb(
+  db: Database,
+  projectId: string,
+  entryId: string,
+  status: Status,
+  updatedAt?: number,
+): void {
+  updateEntryInDb(
+    db,
+    projectId,
+    entryId,
+    (entry, nextUpdatedAt) => ({ ...entry, status, updatedAt: nextUpdatedAt }),
+    updatedAt,
+  );
+}
+
+function updateEntrySummaryInDb(
+  db: Database,
+  projectId: string,
+  entryId: string,
+  summary: string,
+  updatedAt?: number,
+): void {
+  updateEntryInDb(
+    db,
+    projectId,
+    entryId,
+    (entry, nextUpdatedAt) => ({ ...entry, summary, updatedAt: nextUpdatedAt }),
+    updatedAt,
+  );
+}
+
 const SEARCH_SQL = `SELECT
   e.project_id,
   e.id,
@@ -568,6 +665,13 @@ function createStore(state: StoreState): ProjectMemoryStore {
     loadSourcesForEntry: async (projectId, entryId) => loadSourcesFromDb(active(state), projectId, entryId),
     searchEntries: async (projectId, query, options = {}) =>
       searchEntriesInDb(active(state), projectId, query, options),
+    listEntries: async (projectId, options = {}) => listEntriesInDb(active(state), projectId, options),
+    listEntities: async (projectId, options = {}) => listEntitiesInDb(active(state), projectId, options),
+    listSources: async (projectId, options = {}) => listSourcesInDb(active(state), projectId, options),
+    updateEntryStatus: async (projectId, entryId, status, updatedAt) =>
+      updateEntryStatusInDb(active(state), projectId, entryId, status, updatedAt),
+    updateEntrySummary: async (projectId, entryId, summary, updatedAt) =>
+      updateEntrySummaryInDb(active(state), projectId, entryId, summary, updatedAt),
     countEntities: async (projectId) => countEntitiesInDb(active(state), projectId),
     countEntries: async (projectId) => countEntriesInDb(active(state), projectId),
     countEntriesByStatus: async (projectId) => countEntriesByStatusInDb(active(state), projectId),

--- a/src/project-memory/types.ts
+++ b/src/project-memory/types.ts
@@ -17,7 +17,16 @@ export const EntryTypeValues = [
 ] as const;
 
 export const SensitivityValues = ["public", "internal", "secret"] as const;
-export const StatusValues = ["active", "superseded", "tentative", "hypothesis", "deprecated"] as const;
+export const StatusValues = [
+  "active",
+  "superseded",
+  "tentative",
+  "hypothesis",
+  "deprecated",
+  "archived",
+  "tombstoned",
+  "stale",
+] as const;
 export const RelationKindValues = ["parent", "related", "supersedes"] as const;
 export const SourceKindValues = ["design", "plan", "ledger", "lifecycle", "mindmodel", "manual", "skill"] as const;
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -12,6 +12,7 @@ export {
   createProjectMemoryForgetTool,
   createProjectMemoryHealthTool,
   createProjectMemoryLookupTool,
+  createProjectMemoryMaintainTool,
   createProjectMemoryPromoteTool,
 } from "./project-memory";
 export { createPTYManager, createPtyTools, loadBunPty } from "./pty";

--- a/src/tools/project-memory/forget.ts
+++ b/src/tools/project-memory/forget.ts
@@ -10,7 +10,7 @@ import {
 } from "@/project-memory";
 import { extractErrorMessage } from "@/utils/errors";
 import type { ProjectIdentity } from "@/utils/project-id";
-import { getIdentity, getStore } from "./runtime";
+import { getStore, getWriteIdentity, type ProjectMemoryToolTargetArgs } from "./runtime";
 
 const TARGETS = {
   project: "project",
@@ -22,15 +22,18 @@ const TARGET_VALUES = [TARGETS.project, TARGETS.entity, TARGETS.entry, TARGETS.s
 const PROJECT_PREFIX_LENGTH = 8;
 const DESCRIPTION = `Hard-delete durable project memory entries scoped to the current project.
 
+Use only on explicit user request. Maintenance workers must not use this tool; secret cleanup must go through the store API instead.
+
 Args:
 - target: project, entity, entry, or source
 - entity_id: required when target=entity
 - entry_id: required when target=entry
-- source_kind and pointer: required when target=source`;
+- source_kind and pointer: required when target=source
+- project_target/project_origin/project_alias/project_worktree/session_project_origin/lifecycle_project_origin: optional explicit project target`;
 
 type TargetKind = (typeof TARGET_VALUES)[number];
 
-interface ForgetArgs {
+interface ForgetArgs extends ProjectMemoryToolTargetArgs {
   readonly target: TargetKind;
   readonly entity_id?: string;
   readonly entry_id?: string;
@@ -109,11 +112,17 @@ export function createProjectMemoryForgetTool(ctx: PluginInput): { project_memor
       entry_id: tool.schema.string().optional().describe("Entry id, required when target=entry"),
       source_kind: tool.schema.enum(SourceKindValues).optional().describe("Source kind, required when target=source"),
       pointer: tool.schema.string().optional().describe("Source pointer, required when target=source"),
+      project_target: tool.schema.string().optional().describe("Optional explicit project target identity"),
+      project_origin: tool.schema.string().optional().describe("Optional explicit project git origin"),
+      project_alias: tool.schema.string().optional().describe("Optional explicit project alias"),
+      project_worktree: tool.schema.string().optional().describe("Optional explicit project worktree path"),
+      session_project_origin: tool.schema.string().optional().describe("Optional session project git origin"),
+      lifecycle_project_origin: tool.schema.string().optional().describe("Optional lifecycle project git origin"),
     },
     execute: async (args: ForgetArgs) => {
       try {
         const store = await getStore();
-        const identity = await getIdentity(ctx.directory);
+        const identity = await getWriteIdentity(ctx.directory, args);
         const target = buildTarget(args);
         const counts = await countProject(store, identity, target);
         const outcome = await forget({ store, identity, target });

--- a/src/tools/project-memory/index.ts
+++ b/src/tools/project-memory/index.ts
@@ -1,4 +1,5 @@
 export { createProjectMemoryForgetTool } from "./forget";
 export { createProjectMemoryHealthTool } from "./health";
 export { createProjectMemoryLookupTool } from "./lookup";
+export { createProjectMemoryMaintainTool } from "./maintain";
 export { createProjectMemoryPromoteTool } from "./promote";

--- a/src/tools/project-memory/lookup.ts
+++ b/src/tools/project-memory/lookup.ts
@@ -3,40 +3,62 @@ import { tool } from "@opencode-ai/plugin/tool";
 
 import { EntryTypeValues, formatLookupResults, lookup, type Status, StatusValues } from "@/project-memory";
 import { extractErrorMessage } from "@/utils/errors";
-import { getIdentity, getStore } from "./runtime";
+import { getReadIdentity, getStore, type ProjectMemoryToolTargetArgs } from "./runtime";
 
-const DEFAULT_STATUS: Status = "active";
 const SENSITIVITY_CEILING_VALUES = ["public", "internal"] as const;
+
+interface ProjectMemoryLookupArgs extends ProjectMemoryToolTargetArgs {
+  readonly query: string;
+  readonly type?: (typeof EntryTypeValues)[number];
+  readonly status?: Status;
+  readonly sensitivity_ceiling?: (typeof SENSITIVITY_CEILING_VALUES)[number];
+  readonly limit?: number;
+}
+
+const lookupArgs = {
+  query: tool.schema.string().describe("Topic to search (e.g., 'permission cache TTL')"),
+  type: tool.schema.enum(EntryTypeValues).optional().describe("Filter by entry type"),
+  status: tool.schema
+    .enum(StatusValues)
+    .optional()
+    .describe("Filter by status (default: active; archived/tombstoned/deprecated/superseded require explicit status)"),
+  sensitivity_ceiling: tool.schema
+    .enum(SENSITIVITY_CEILING_VALUES)
+    .optional()
+    .describe("Cap returned entries at this sensitivity (public or internal)"),
+  limit: tool.schema.number().optional().describe("Max results (default: 10)"),
+  project_target: tool.schema.string().optional().describe("Optional explicit project target identity"),
+  project_origin: tool.schema.string().optional().describe("Optional explicit project git origin"),
+  project_alias: tool.schema.string().optional().describe("Optional explicit project alias"),
+  project_worktree: tool.schema.string().optional().describe("Optional explicit project worktree path"),
+  session_project_origin: tool.schema.string().optional().describe("Optional session project git origin"),
+  lifecycle_project_origin: tool.schema.string().optional().describe("Optional lifecycle project git origin"),
+};
+
+async function executeLookup(ctx: PluginInput, args: ProjectMemoryLookupArgs): Promise<string> {
+  const store = await getStore();
+  const identity = await getReadIdentity(ctx.directory, args);
+  const hits = await lookup({
+    store,
+    identity,
+    query: args.query,
+    type: args.type,
+    status: args.status,
+    sensitivityCeiling: args.sensitivity_ceiling,
+    limit: args.limit,
+  });
+  return formatLookupResults(args.query, hits);
+}
 
 export function createProjectMemoryLookupTool(ctx: PluginInput): { project_memory_lookup: ToolDefinition } {
   const project_memory_lookup = tool({
     description: `Look up durable project memory entries (decisions, lessons, risks, facts, procedures) scoped to the current project.
-Prefer this over reading raw thoughts/ files when you only need conclusions.`,
-    args: {
-      query: tool.schema.string().describe("Topic to search (e.g., 'permission cache TTL')"),
-      type: tool.schema.enum(EntryTypeValues).optional().describe("Filter by entry type"),
-      status: tool.schema.enum(StatusValues).optional().describe("Filter by status (default: active)"),
-      sensitivity_ceiling: tool.schema
-        .enum(SENSITIVITY_CEILING_VALUES)
-        .optional()
-        .describe("Cap returned entries at this sensitivity (public or internal)"),
-      limit: tool.schema.number().optional().describe("Max results (default: 10)"),
-    },
-    execute: async ({ query, type, status, sensitivity_ceiling: sensitivityCeiling, limit }) => {
+Prefer this over reading raw thoughts/ files when you only need conclusions.
+Defaults to active entries only; archived, tombstoned, deprecated, and superseded entries require an explicit status filter.`,
+    args: lookupArgs,
+    execute: async (args) => {
       try {
-        const store = await getStore();
-        const identity = await getIdentity(ctx.directory);
-        const lookupInput = {
-          store,
-          identity,
-          query,
-          type,
-          status: status ?? DEFAULT_STATUS,
-          sensitivityCeiling,
-          limit,
-        };
-        const hits = await lookup(lookupInput);
-        return formatLookupResults(query, hits);
+        return await executeLookup(ctx, args as ProjectMemoryLookupArgs);
       } catch (error) {
         return `## Error\n\n${extractErrorMessage(error)}`;
       }

--- a/src/tools/project-memory/maintain.ts
+++ b/src/tools/project-memory/maintain.ts
@@ -1,0 +1,139 @@
+import type { PluginInput, ToolDefinition } from "@opencode-ai/plugin";
+import { tool } from "@opencode-ai/plugin/tool";
+import type {
+  MaintenancePlan,
+  MaintenancePlanItem,
+  MaintenanceReason,
+  MaintenanceRunOutcome,
+} from "@/project-memory/maintenance/types";
+import { buildMaintenancePlan, runProjectMemoryMaintenance } from "@/project-memory/maintenance/worker";
+import { extractErrorMessage } from "@/utils/errors";
+import { getMaintenanceIdentity, getStore, type ProjectMemoryToolTargetArgs } from "./runtime";
+
+const DESCRIPTION = `Run project memory maintenance for the current project.
+
+Defaults to a manual dry-run. Passing dry_run=false applies safe maintenance actions and writes a sanitized journal entry.
+
+Args:
+- dry_run: Preview only by default; set false to apply safe archive/supersede/stale/tombstone/delete actions
+- reason: manual, scheduled, or terminal; defaults to manual
+- project_target/project_origin/project_alias/project_worktree/session_project_origin/lifecycle_project_origin: optional explicit project target`;
+
+const ERROR_HEADER = "## Error";
+const PLAN_HEADER = "## Project memory maintenance plan";
+const APPLIED_HEADER = "## Project memory maintenance applied";
+const PLAN_TABLE_HEADER = "| Entry ID | Action | Kind | Safe | Reason |";
+const PLAN_TABLE_SEPARATOR = "| --- | --- | --- | --- | --- |";
+const NO_PLAN_ITEMS = "No maintenance actions planned.";
+const LINE_BREAK = "\n";
+const DOUBLE_LINE_BREAK = "\n\n";
+const REASON_VALUES = ["manual", "scheduled", "terminal"] as const;
+const NON_BLOCKING_ACTIONS = new Set([
+  "archive",
+  "supersede",
+  "mark_stale",
+  "tombstone",
+  "hard_delete_secret",
+  "deduplicate",
+]);
+
+interface ProjectMemoryMaintainArgs extends ProjectMemoryToolTargetArgs {
+  readonly dry_run?: boolean;
+  readonly reason?: (typeof REASON_VALUES)[number];
+}
+
+function escapeCell(value: string): string {
+  return value.replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
+}
+
+function formatPlanRow(item: MaintenancePlanItem): string {
+  return `| \`${escapeCell(item.entryId)}\` | ${item.action} | ${item.kind} | ${item.safeByDefault ? "yes" : "no"} | ${escapeCell(item.reason)} |`;
+}
+
+function formatPlanTable(plan: MaintenancePlan): string {
+  if (plan.items.length === 0) return NO_PLAN_ITEMS;
+  return [PLAN_TABLE_HEADER, PLAN_TABLE_SEPARATOR, ...plan.items.map(formatPlanRow)].join(LINE_BREAK);
+}
+
+function plannedUnsafeCount(plan: MaintenancePlan): number {
+  return plan.items.filter((item) => !item.safeByDefault || !NON_BLOCKING_ACTIONS.has(item.action)).length;
+}
+
+function formatPlan(plan: MaintenancePlan, dryRun: boolean): string {
+  return [
+    PLAN_HEADER,
+    `- **Project ID:** \`${plan.projectId}\``,
+    `- **Reason:** ${plan.reason}`,
+    `- **Dry run:** ${dryRun}`,
+    `- **Planned actions:** ${plan.items.length}`,
+    `- **Blocked without review:** ${plannedUnsafeCount(plan)}`,
+    "",
+    formatPlanTable(plan),
+  ].join(LINE_BREAK);
+}
+
+function formatWarnings(warnings: readonly string[]): string {
+  if (warnings.length === 0) return "- **Warnings:** None";
+  return ["- **Warnings:**", ...warnings.map((warning) => `  - ${escapeCell(warning)}`)].join(LINE_BREAK);
+}
+
+function formatApplyOutcome(outcome: MaintenanceRunOutcome): string {
+  return [
+    APPLIED_HEADER,
+    `- **Applied:** ${outcome.applied}`,
+    `- **Skipped:** ${outcome.skipped}`,
+    `- **Blocked:** ${outcome.blocked}`,
+    `- **Journal:** \`${outcome.journalPath}\``,
+    formatWarnings(outcome.warnings),
+  ].join(LINE_BREAK);
+}
+
+function formatError(error: unknown): string {
+  const message = extractErrorMessage(error);
+  if (message.toLowerCase().includes("degraded identity")) {
+    return `${ERROR_HEADER}${DOUBLE_LINE_BREAK}Maintenance refused because degraded identity cannot write durable project memory. Configure a stable git origin or pass an explicit project origin.`;
+  }
+  return `${ERROR_HEADER}${DOUBLE_LINE_BREAK}${message}`;
+}
+
+export function createProjectMemoryMaintainTool(ctx: PluginInput): { project_memory_maintain: ToolDefinition } {
+  const project_memory_maintain = tool({
+    description: DESCRIPTION,
+    args: {
+      dry_run: tool.schema.boolean().optional().describe("Preview only by default; set false to apply safe actions"),
+      reason: tool.schema.enum(REASON_VALUES).optional().describe("Maintenance reason: manual, scheduled, or terminal"),
+      project_target: tool.schema.string().optional().describe("Optional explicit project target identity"),
+      project_origin: tool.schema.string().optional().describe("Optional explicit project git origin"),
+      project_alias: tool.schema.string().optional().describe("Optional explicit project alias"),
+      project_worktree: tool.schema.string().optional().describe("Optional explicit project worktree path"),
+      session_project_origin: tool.schema.string().optional().describe("Optional session project git origin"),
+      lifecycle_project_origin: tool.schema.string().optional().describe("Optional lifecycle project git origin"),
+    },
+    execute: async (args: ProjectMemoryMaintainArgs) => {
+      try {
+        const dryRun = args.dry_run ?? true;
+        const reason = (args.reason ?? "manual") as MaintenanceReason;
+        const identity = await getMaintenanceIdentity(ctx.directory, args);
+        const store = await getStore();
+
+        if (dryRun) {
+          return formatPlan(await buildMaintenancePlan({ store, identity, reason }), dryRun);
+        }
+
+        const outcome = await runProjectMemoryMaintenance({
+          projectId: identity.projectId,
+          reason,
+          dryRun: false,
+          triggeredBy: "project_memory_maintain",
+          store,
+          identity,
+        });
+        return formatApplyOutcome(outcome);
+      } catch (error) {
+        return formatError(error);
+      }
+    },
+  });
+
+  return { project_memory_maintain };
+}

--- a/src/tools/project-memory/promote.ts
+++ b/src/tools/project-memory/promote.ts
@@ -9,7 +9,7 @@ import {
   SourceKindValues,
 } from "@/project-memory";
 import { extractErrorMessage } from "@/utils/errors";
-import { getIdentity, getStore } from "./runtime";
+import { getStore, getWriteIdentity, type ProjectMemoryToolTargetArgs } from "./runtime";
 
 const DESCRIPTION = `Promote markdown decisions, lessons, risks, and notes into durable project memory.
 
@@ -31,6 +31,13 @@ const NO_ACCEPTED = "No accepted candidates.";
 const NO_REJECTED = "No rejected candidates.";
 const DEGRADED_IDENTITY_REASON = "degraded_identity";
 const LINE_BREAK = "\n";
+
+interface ProjectMemoryPromoteArgs extends ProjectMemoryToolTargetArgs {
+  readonly markdown: string;
+  readonly entity_name: string;
+  readonly source_kind: (typeof SourceKindValues)[number];
+  readonly pointer: string;
+}
 
 function escapeCell(value: string): string {
   return value.replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
@@ -73,6 +80,21 @@ function formatRefusal(reason: string): string {
   return `${REFUSED_HEADER}${LINE_BREAK}${LINE_BREAK}Promotion refused: ${escapeCell(reason)}.`;
 }
 
+function formatError(error: unknown): string {
+  const message = extractErrorMessage(error);
+  const normalized = message.toLowerCase();
+  if (normalized.includes("degraded identity")) {
+    return `${ERROR_HEADER}${LINE_BREAK}${LINE_BREAK}${REFUSED_HEADER}${LINE_BREAK}${LINE_BREAK}Promotion refused because degraded identity cannot write durable project memory. Configure a stable git origin or pass an explicit project origin.`;
+  }
+  if (normalized.includes("ambiguous")) {
+    return `${ERROR_HEADER}${LINE_BREAK}${LINE_BREAK}${REFUSED_HEADER}${LINE_BREAK}${LINE_BREAK}Promotion refused because project identity is ambiguous. ${escapeCell(message)}.`;
+  }
+  if (normalized.includes("unresolved")) {
+    return `${ERROR_HEADER}${LINE_BREAK}${LINE_BREAK}${REFUSED_HEADER}${LINE_BREAK}${LINE_BREAK}Promotion refused because project identity could not be resolved. ${escapeCell(message)}.`;
+  }
+  return `${ERROR_HEADER}${LINE_BREAK}${LINE_BREAK}${message}`;
+}
+
 function formatNote(outcome: PromoteOutcome): string {
   return `**Note**: ${outcome.accepted.length} accepted, ${outcome.rejected.length} rejected`;
 }
@@ -98,11 +120,17 @@ export function createProjectMemoryPromoteTool(ctx: PluginInput): { project_memo
       entity_name: tool.schema.string().describe("Default entity name for extracted candidates"),
       source_kind: tool.schema.enum(SourceKindValues).describe("Source kind for promotion provenance"),
       pointer: tool.schema.string().describe("Stable source pointer for promotion provenance"),
+      project_target: tool.schema.string().optional().describe("Optional explicit project target identity"),
+      project_origin: tool.schema.string().optional().describe("Optional explicit project git origin"),
+      project_alias: tool.schema.string().optional().describe("Optional explicit project alias"),
+      project_worktree: tool.schema.string().optional().describe("Optional explicit project worktree path"),
+      session_project_origin: tool.schema.string().optional().describe("Optional session project git origin"),
+      lifecycle_project_origin: tool.schema.string().optional().describe("Optional lifecycle project git origin"),
     },
     execute: async (args) => {
       try {
         const store = await getStore();
-        const identity = await getIdentity(ctx.directory);
+        const identity = await getWriteIdentity(ctx.directory, args as ProjectMemoryPromoteArgs);
         const outcome = await promoteMarkdown({
           store,
           identity,
@@ -113,7 +141,11 @@ export function createProjectMemoryPromoteTool(ctx: PluginInput): { project_memo
         });
         return formatOutcome(outcome);
       } catch (error) {
-        return `${ERROR_HEADER}${LINE_BREAK}${LINE_BREAK}${extractErrorMessage(error)}`;
+        const message = extractErrorMessage(error);
+        if (message.includes("degraded identity cannot write durable project memory")) {
+          return formatRefusal(DEGRADED_IDENTITY_REASON);
+        }
+        return formatError(error);
       }
     },
   });

--- a/src/tools/project-memory/runtime.ts
+++ b/src/tools/project-memory/runtime.ts
@@ -4,14 +4,154 @@ import {
   resetDefaultProjectMemoryStoreForTest,
   setDefaultProjectMemoryStoreForTest,
 } from "@/project-memory";
-import { type ProjectIdentity, resolveProjectId } from "@/utils/project-id";
+import { createProjectRegistry, type ProjectRegistryRecord } from "@/project-memory/registry";
+import {
+  isDegradedProjectIdentity,
+  normalizeProjectOrigin,
+  type ProjectIdentity,
+  projectIdForSource,
+  resolveProjectId,
+} from "@/utils/project-id";
+
+export interface ProjectMemoryToolTargetArgs {
+  readonly project_target?: string;
+  readonly project_origin?: string;
+  readonly project_alias?: string;
+  readonly project_worktree?: string;
+  readonly session_project_origin?: string;
+  readonly lifecycle_project_origin?: string;
+}
+
+type IdentityMode = "read" | "write" | "maintenance";
+
+const FIELD_PRIORITY = [
+  "project_origin",
+  "project_target",
+  "project_alias",
+  "project_worktree",
+  "session_project_origin",
+  "lifecycle_project_origin",
+] as const;
+
+function nonEmpty(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function identityForOrigin(origin: string): ProjectIdentity {
+  const source = normalizeProjectOrigin(origin);
+  return { projectId: projectIdForSource(source), kind: "origin", source };
+}
+
+function identityForRecord(record: ProjectRegistryRecord): ProjectIdentity {
+  if (record.origin) return identityForOrigin(record.origin);
+  return { projectId: record.projectId, kind: "origin", source: record.projectId };
+}
+
+function identityKey(identity: ProjectIdentity): string {
+  return `${identity.projectId}\0${identity.kind}\0${identity.source}`;
+}
+
+function describeTarget(field: string, value: string): string {
+  return `${field}=${value}`;
+}
+
+function uniqueTargetCount(candidates: readonly { readonly identity: ProjectIdentity }[]): number {
+  return new Set(candidates.map((candidate) => identityKey(candidate.identity))).size;
+}
+
+function describeCandidates(candidates: readonly { readonly field: string; readonly value: string }[]): string {
+  return candidates.map((candidate) => describeTarget(candidate.field, candidate.value)).join(", ");
+}
+
+async function findRegistryIdentity(field: string, value: string): Promise<ProjectIdentity | null> {
+  const registry = createProjectRegistry();
+  const matches =
+    field === "project_alias" || field === "project_target"
+      ? await registry.findByAlias(value)
+      : await registry.findByWorktree(value);
+
+  if (matches.length === 0) return null;
+  if (matches.length > 1) {
+    throw new Error(`ambiguous project target: ${describeTarget(field, value)} matched ${matches.length} projects`);
+  }
+  return identityForRecord(matches[0]);
+}
+
+async function resolveCandidate(field: (typeof FIELD_PRIORITY)[number], value: string): Promise<ProjectIdentity> {
+  if (field === "project_alias" || field === "project_worktree") {
+    const registryMatch = await findRegistryIdentity(field, value);
+    if (!registryMatch) {
+      throw new Error(`unknown project target: ${describeTarget(field, value)} did not match registry`);
+    }
+    return registryMatch;
+  }
+
+  if (field === "project_target") {
+    const registryMatch = await findRegistryIdentity(field, value);
+    return registryMatch ?? identityForOrigin(value);
+  }
+
+  return identityForOrigin(value);
+}
+
+async function resolveTargetIdentity(args: ProjectMemoryToolTargetArgs | undefined): Promise<ProjectIdentity | null> {
+  if (!args) return null;
+
+  const candidates: { readonly field: string; readonly value: string; readonly identity: ProjectIdentity }[] = [];
+
+  for (const field of FIELD_PRIORITY) {
+    const value = nonEmpty(args[field]);
+    if (!value) continue;
+
+    candidates.push({ field, value, identity: await resolveCandidate(field, value) });
+  }
+
+  if (candidates.length === 0) return null;
+
+  if (uniqueTargetCount(candidates) > 1) {
+    throw new Error(`ambiguous project target: ${describeCandidates(candidates)} resolved to multiple projects`);
+  }
+
+  return candidates[0].identity;
+}
+
+async function getIdentityForMode(
+  directory: string,
+  args: ProjectMemoryToolTargetArgs | undefined,
+  mode: IdentityMode,
+): Promise<ProjectIdentity> {
+  const identity = (await resolveTargetIdentity(args)) ?? (await resolveProjectId(directory));
+  if (mode !== "read" && isDegradedProjectIdentity(identity)) {
+    throw new Error("degraded identity cannot write durable project memory. Configure a stable git origin first.");
+  }
+  return identity;
+}
 
 export async function getStore(): Promise<ProjectMemoryStore> {
   return getDefaultStore();
 }
 
+export async function getReadIdentity(directory: string, args?: ProjectMemoryToolTargetArgs): Promise<ProjectIdentity> {
+  return getIdentityForMode(directory, args, "read");
+}
+
+export async function getWriteIdentity(
+  directory: string,
+  args?: ProjectMemoryToolTargetArgs,
+): Promise<ProjectIdentity> {
+  return getIdentityForMode(directory, args, "write");
+}
+
+export async function getMaintenanceIdentity(
+  directory: string,
+  args?: ProjectMemoryToolTargetArgs,
+): Promise<ProjectIdentity> {
+  return getIdentityForMode(directory, args, "maintenance");
+}
+
 export async function getIdentity(directory: string): Promise<ProjectIdentity> {
-  return resolveProjectId(directory);
+  return getReadIdentity(directory);
 }
 
 export function setProjectMemoryStoreForTest(memory: ProjectMemoryStore | null): void {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -14,6 +14,7 @@ const REVIEW_TIMEOUT_MINUTES = 10;
 const SUBAGENT_TRANSIENT_BACKOFF_FIRST_MS = 5000;
 const SUBAGENT_TRANSIENT_BACKOFF_SECOND_MS = 15_000;
 const NOTIFICATION_DEDUPE_TTL_MS = 21_600_000;
+const PROJECT_MEMORY_CONFIG_DIR = join(homedir(), ".config", "opencode", "project-memory");
 
 const OCTTO_PORT_ENV = "OCTTO_PORT";
 const OCTTO_PUBLIC_BASE_URL_ENV = "OCTTO_PUBLIC_BASE_URL";
@@ -276,14 +277,22 @@ export const config = {
   },
 
   projectMemory: {
-    storageDir: join(homedir(), ".config", "opencode", "project-memory"),
+    storageDir: PROJECT_MEMORY_CONFIG_DIR,
+    registryFile: join(PROJECT_MEMORY_CONFIG_DIR, "registry.json"),
+    maintenanceJournalDir: join(PROJECT_MEMORY_CONFIG_DIR, "maintenance-journal"),
     dbFileName: "memory.db",
     sensitivity: ["public", "internal", "secret"] as readonly string[],
     statuses: ["active", "superseded", "tentative", "hypothesis", "deprecated"] as readonly string[],
+    defaultLookupStatuses: ["active"] as readonly string[],
+    historicalStatuses: ["active", "superseded", "tentative", "hypothesis", "deprecated"] as readonly string[],
     defaultLookupLimit: 10,
     snippetMaxChars: 240,
     promoteOnLifecycleFinish: false,
     refuseWritesOnDegradedIdentity: true,
+    maintenanceLockTtlMs: 600_000,
+    maintenanceSnapshotLimit: 200,
+    maintenanceEnabled: true,
+    maintenanceTerminalTriggerEnabled: true,
   },
 
   skillAutopilot: {

--- a/src/utils/project-id.ts
+++ b/src/utils/project-id.ts
@@ -19,7 +19,11 @@ function hash(input: string): string {
   return createHash("sha1").update(input).digest("hex").slice(0, ID_LENGTH);
 }
 
-function normalizeRemote(remote: string): string {
+export function projectIdForSource(source: string): string {
+  return hash(source);
+}
+
+export function normalizeProjectOrigin(remote: string): string {
   const trimmed = remote.trim();
   const sshMatch = SSH_REMOTE_PATTERN.exec(trimmed);
   if (sshMatch) {
@@ -35,6 +39,10 @@ function normalizeRemote(remote: string): string {
   } catch {
     return trimmed.toLowerCase().replace(TRAILING_GIT, "");
   }
+}
+
+export function isDegradedProjectIdentity(identity: ProjectIdentity): boolean {
+  return identity.kind !== "origin";
 }
 
 async function readOrigin(cwd: string): Promise<string | null> {
@@ -61,9 +69,9 @@ async function readToplevel(cwd: string): Promise<string> {
 export async function resolveProjectId(cwd: string): Promise<ProjectIdentity> {
   const origin = await readOrigin(cwd);
   if (origin) {
-    const source = normalizeRemote(origin);
-    return { projectId: hash(source), kind: "origin", source };
+    const source = normalizeProjectOrigin(origin);
+    return { projectId: projectIdForSource(source), kind: "origin", source };
   }
   const toplevel = await readToplevel(cwd);
-  return { projectId: hash(toplevel), kind: "path", source: toplevel };
+  return { projectId: projectIdForSource(toplevel), kind: "path", source: toplevel };
 }

--- a/tests/integration/project-memory-identity-blocking.test.ts
+++ b/tests/integration/project-memory-identity-blocking.test.ts
@@ -1,0 +1,254 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { PluginInput, ToolDefinition } from "@opencode-ai/plugin";
+import type { ToolContext, ToolResult } from "@opencode-ai/plugin/tool";
+
+import {
+  createProjectMemoryStore,
+  type Entity,
+  type Entry,
+  type ProjectMemoryStore,
+  type Source,
+} from "@/project-memory";
+import { type MaintenanceJournalEvent, readMaintenanceJournal } from "@/project-memory/maintenance/journal";
+import { createProjectRegistry } from "@/project-memory/registry";
+import {
+  createProjectMemoryHealthTool,
+  createProjectMemoryLookupTool,
+  createProjectMemoryMaintainTool,
+  createProjectMemoryPromoteTool,
+} from "@/tools/project-memory";
+import { resetProjectMemoryRuntimeForTest, setProjectMemoryStoreForTest } from "@/tools/project-memory/runtime";
+import { config } from "@/utils/config";
+import { projectIdForSource, resolveProjectId } from "@/utils/project-id";
+
+const TOOL_CONTEXT = {} as unknown as ToolContext;
+const ROOT_PREFIX = "project-memory-identity-blocking-";
+const PROJECT_ALIAS = "micode";
+const ORIGIN_A = "https://github.com/Wuxie233/micode.git";
+const ORIGIN_B = "https://github.com/Wuxie233/micode-shadow.git";
+const SOURCE_A = "github.com/wuxie233/micode";
+const SOURCE_B = "github.com/wuxie233/micode-shadow";
+const PROJECT_A = projectIdForSource(SOURCE_A);
+const PROJECT_B = projectIdForSource(SOURCE_B);
+const ALIAS_PROJECT = projectIdForSource(PROJECT_ALIAS);
+const ENTITY_NAME = "project-memory";
+const ENTRY_ID_A = "entry-archive-a";
+const ENTRY_ID_B = "entry-archive-b";
+const CREATED_AT = 1;
+const OLD = 1;
+const PROMOTED_DECISION = "Ambiguous alias promotion must not pick a project";
+const PROMOTION_MARKDOWN = `## Decisions\n- ${PROMOTED_DECISION}\n`;
+const POINTER = "thoughts/lifecycle/identity-blocking.md";
+const LOOKUP_QUERY = "identity blocking sentinel";
+const EXPECTED_ZERO = 0;
+const EXPECTED_ONE = 1;
+
+type ExecuteSignature = (raw: unknown, ctx: ToolContext) => Promise<ToolResult>;
+
+let root: string;
+let store: ProjectMemoryStore;
+let originalRegistryFile: string;
+let originalJournalDir: string;
+
+function stringify(outcome: ToolResult): string {
+  if (typeof outcome === "string") return outcome;
+  return outcome.output;
+}
+
+async function executeTool(toolDef: ToolDefinition, args: Record<string, unknown> = {}): Promise<string> {
+  const exec = toolDef.execute.bind(toolDef) as unknown as ExecuteSignature;
+  return stringify(await exec(args, TOOL_CONTEXT));
+}
+
+function createCtx(directory: string): PluginInput {
+  return { directory } as unknown as PluginInput;
+}
+
+function createPlainDirectory(name: string): string {
+  const directory = join(root, name);
+  mkdirSync(directory, { recursive: true });
+  return directory;
+}
+
+async function seedAmbiguousAliasRegistry(): Promise<void> {
+  const registry = createProjectRegistry({ filePath: config.projectMemory.registryFile });
+  await registry.upsert({
+    projectId: "registry-project-a",
+    origin: ORIGIN_A,
+    aliases: [PROJECT_ALIAS],
+    worktrees: [],
+    updatedAt: 1,
+  });
+  await registry.upsert({
+    projectId: "registry-project-b",
+    origin: ORIGIN_B,
+    aliases: [PROJECT_ALIAS],
+    worktrees: [],
+    updatedAt: 2,
+  });
+}
+
+function entity(projectId: string, id: string): Entity {
+  return {
+    projectId,
+    id,
+    kind: "module",
+    name: "project-memory",
+    createdAt: CREATED_AT,
+    updatedAt: CREATED_AT,
+  };
+}
+
+function entry(projectId: string, entityId: string, id: string): Entry {
+  return {
+    projectId,
+    id,
+    entityId,
+    type: "note",
+    title: "Archive me",
+    summary: "Old low-signal note used to prove blocked maintenance does not mutate entries.",
+    status: "deprecated",
+    sensitivity: "internal",
+    createdAt: CREATED_AT,
+    updatedAt: OLD,
+  };
+}
+
+function source(projectId: string, entryId: string): Source {
+  return {
+    projectId,
+    id: `source-${entryId}`,
+    entryId,
+    kind: "manual",
+    pointer: `manual://${entryId}`,
+    createdAt: CREATED_AT,
+  };
+}
+
+async function seedMaintenanceCandidate(projectId: string, entryId: string): Promise<void> {
+  const entityId = `entity-${entryId}`;
+  await store.upsertEntity(entity(projectId, entityId));
+  await store.upsertEntry(entry(projectId, entityId, entryId));
+  await store.upsertSource(source(projectId, entryId));
+}
+
+function isBlockedJournalEvent(event: MaintenanceJournalEvent): boolean {
+  return event.action === "needs_review" && event.counts?.blocked === EXPECTED_ONE;
+}
+
+async function expectOnlyOptionalBlockedJournal(projectId: string): Promise<void> {
+  const journal = await readMaintenanceJournal(projectId);
+  expect(journal.every(isBlockedJournalEvent)).toBe(true);
+}
+
+beforeEach(async () => {
+  root = mkdtempSync(join(tmpdir(), ROOT_PREFIX));
+  originalRegistryFile = config.projectMemory.registryFile;
+  originalJournalDir = config.projectMemory.maintenanceJournalDir;
+  (config.projectMemory as { registryFile: string; maintenanceJournalDir: string }).registryFile = join(
+    root,
+    "registry.json",
+  );
+  (config.projectMemory as { registryFile: string; maintenanceJournalDir: string }).maintenanceJournalDir = join(
+    root,
+    "journal",
+  );
+  store = createProjectMemoryStore({ dbDir: join(root, "db") });
+  await store.initialize();
+  setProjectMemoryStoreForTest(store);
+  await seedAmbiguousAliasRegistry();
+});
+
+afterEach(async () => {
+  await resetProjectMemoryRuntimeForTest();
+  (config.projectMemory as { registryFile: string; maintenanceJournalDir: string }).registryFile = originalRegistryFile;
+  (config.projectMemory as { registryFile: string; maintenanceJournalDir: string }).maintenanceJournalDir =
+    originalJournalDir;
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("project memory identity blocking", () => {
+  it("refuses non-project promotion through an ambiguous alias without writing entries", async () => {
+    const directory = createPlainDirectory("non-project-promote");
+    const toolDef = createProjectMemoryPromoteTool(createCtx(directory)).project_memory_promote;
+
+    const output = await executeTool(toolDef, {
+      markdown: PROMOTION_MARKDOWN,
+      entity_name: ENTITY_NAME,
+      source_kind: "lifecycle",
+      pointer: POINTER,
+      project_alias: PROJECT_ALIAS,
+    });
+
+    expect(output).toContain("## Error");
+    expect(output).toContain("## Project memory promotion refused");
+    expect(output.toLowerCase()).toContain("ambiguous");
+    expect(output).toContain(`project_alias=${PROJECT_ALIAS}`);
+    expect(await store.countEntries(PROJECT_A)).toBe(EXPECTED_ZERO);
+    expect(await store.countEntries(PROJECT_B)).toBe(EXPECTED_ZERO);
+    expect(await store.countEntries(ALIAS_PROJECT)).toBe(EXPECTED_ZERO);
+  });
+
+  it("blocks ambiguous alias maintenance without mutating either matched project", async () => {
+    const directory = createPlainDirectory("non-project-maintain");
+    await seedMaintenanceCandidate(PROJECT_A, ENTRY_ID_A);
+    await seedMaintenanceCandidate(PROJECT_B, ENTRY_ID_B);
+    const toolDef = createProjectMemoryMaintainTool(createCtx(directory)).project_memory_maintain;
+
+    const output = await executeTool(toolDef, { dry_run: false, project_alias: PROJECT_ALIAS });
+
+    expect(output).toContain("## Error");
+    expect(output.toLowerCase()).toContain("ambiguous");
+    expect(output).toContain(`project_alias=${PROJECT_ALIAS}`);
+    expect(await store.loadEntry(PROJECT_A, ENTRY_ID_A)).toMatchObject({ status: "deprecated" });
+    expect(await store.loadEntry(PROJECT_B, ENTRY_ID_B)).toMatchObject({ status: "deprecated" });
+    await expectOnlyOptionalBlockedJournal(PROJECT_A);
+    await expectOnlyOptionalBlockedJournal(PROJECT_B);
+  });
+
+  it("refuses path-only promote and maintenance writes because degraded identities cannot write", async () => {
+    const directory = createPlainDirectory("path-only-write");
+    const identity = await resolveProjectId(directory);
+    const promote = createProjectMemoryPromoteTool(createCtx(directory)).project_memory_promote;
+    const maintain = createProjectMemoryMaintainTool(createCtx(directory)).project_memory_maintain;
+
+    const promoted = await executeTool(promote, {
+      markdown: PROMOTION_MARKDOWN,
+      entity_name: ENTITY_NAME,
+      source_kind: "lifecycle",
+      pointer: POINTER,
+    });
+    const maintained = await executeTool(maintain, { dry_run: false });
+
+    expect(identity.kind).toBe("path");
+    expect(promoted).toContain("## Project memory promotion refused");
+    expect(promoted.toLowerCase()).toContain("degraded identity");
+    expect(maintained).toContain("## Error");
+    expect(maintained.toLowerCase()).toContain("degraded identity");
+    expect(await store.countEntries(identity.projectId)).toBe(EXPECTED_ZERO);
+    expect(await store.countEntities(identity.projectId)).toBe(EXPECTED_ZERO);
+  });
+
+  it("allows degraded read-only health and lookup while leaving the path-only project empty", async () => {
+    const directory = createPlainDirectory("path-only-read");
+    const identity = await resolveProjectId(directory);
+    const health = createProjectMemoryHealthTool(createCtx(directory)).project_memory_health;
+    const lookup = createProjectMemoryLookupTool(createCtx(directory)).project_memory_lookup;
+
+    const healthOutput = await executeTool(health);
+    const lookupOutput = await executeTool(lookup, { query: LOOKUP_QUERY, limit: 5 });
+
+    expect(identity.kind).toBe("path");
+    expect(healthOutput).toContain("## Project Memory Health");
+    expect(healthOutput).toContain("- **Identity:** `path`");
+    expect(healthOutput).toContain("identity_degraded: origin not resolved");
+    expect(lookupOutput).toContain("## Project Memory");
+    expect(lookupOutput).toContain("No project memory entries");
+    expect(await store.countEntries(identity.projectId)).toBe(EXPECTED_ZERO);
+    expect(await store.countEntities(identity.projectId)).toBe(EXPECTED_ZERO);
+    expect(await store.countSources(identity.projectId)).toBe(EXPECTED_ZERO);
+  });
+});

--- a/tests/integration/project-memory-identity-target.test.ts
+++ b/tests/integration/project-memory-identity-target.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { PluginInput, ToolDefinition } from "@opencode-ai/plugin";
+import type { ToolContext, ToolResult } from "@opencode-ai/plugin/tool";
+import { $ } from "bun";
+
+import { createProjectMemoryStore, type ProjectMemoryStore } from "@/project-memory";
+import { createProjectMemoryLookupTool, createProjectMemoryPromoteTool } from "@/tools/project-memory";
+import { resetProjectMemoryRuntimeForTest, setProjectMemoryStoreForTest } from "@/tools/project-memory/runtime";
+import { resolveProjectId } from "@/utils/project-id";
+
+const PREFIX = "project-memory-identity-target-";
+const TEST_TIMEOUT_MS = 20_000;
+const ORIGIN = "https://github.com/Wuxie233/micode.git";
+const UNRELATED_ORIGIN = "https://github.com/Wuxie233/unrelated-memory.git";
+const ACTUAL_REPO = "actual-repo";
+const UNRELATED_REPO = "unrelated-repo";
+const NON_GIT_DIR = "non-git";
+const ENTITY_NAME = "identity-target";
+const POINTER = "thoughts/lifecycle/identity-target.md";
+const DECISION = "Identity target sentinel resolves explicit project origin across non git directories";
+const MARKDOWN = `## Decisions\n- ${DECISION}\n`;
+const QUERY = "identity target sentinel";
+const LIMIT = 5;
+const TOOL_CONTEXT = {} as unknown as ToolContext;
+
+type ExecuteSignature = (raw: unknown, context: ToolContext) => Promise<ToolResult>;
+
+let root: string;
+let memory: ProjectMemoryStore;
+
+function createContext(directory: string): PluginInput {
+  return { directory } as PluginInput;
+}
+
+function stringify(outcome: ToolResult): string {
+  if (typeof outcome === "string") return outcome;
+  return outcome.output;
+}
+
+async function executeTool(toolDef: ToolDefinition, args: Record<string, unknown>): Promise<string> {
+  const execute = toolDef.execute.bind(toolDef) as ExecuteSignature;
+  return stringify(await execute(args, TOOL_CONTEXT));
+}
+
+async function createRepo(name: string, origin: string): Promise<string> {
+  const directory = join(root, name);
+  mkdirSync(directory, { recursive: true });
+  await $`git init -q`.cwd(directory);
+  await $`git remote add origin ${origin}`.cwd(directory);
+  return directory;
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), PREFIX));
+  memory = createProjectMemoryStore({ dbDir: join(root, "memory") });
+  setProjectMemoryStoreForTest(memory);
+});
+
+afterEach(async () => {
+  await resetProjectMemoryRuntimeForTest();
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("project memory explicit identity target", () => {
+  it(
+    "promotes from a non-git directory to an explicit origin and looks it up from the matching repo only",
+    async () => {
+      const actualRepo = await createRepo(ACTUAL_REPO, ORIGIN);
+      const unrelatedRepo = await createRepo(UNRELATED_REPO, UNRELATED_ORIGIN);
+      const nonGit = join(root, NON_GIT_DIR);
+      mkdirSync(nonGit, { recursive: true });
+
+      const actualIdentity = await resolveProjectId(actualRepo);
+      const unrelatedIdentity = await resolveProjectId(unrelatedRepo);
+      const promote = createProjectMemoryPromoteTool(createContext(nonGit)).project_memory_promote;
+      const lookupActual = createProjectMemoryLookupTool(createContext(actualRepo)).project_memory_lookup;
+      const lookupUnrelated = createProjectMemoryLookupTool(createContext(unrelatedRepo)).project_memory_lookup;
+
+      const promoted = await executeTool(promote, {
+        markdown: MARKDOWN,
+        entity_name: ENTITY_NAME,
+        source_kind: "lifecycle",
+        pointer: POINTER,
+        project_origin: ORIGIN,
+      });
+      const actualHits = await executeTool(lookupActual, { query: QUERY, limit: LIMIT });
+      const unrelatedHits = await executeTool(lookupUnrelated, { query: QUERY, limit: LIMIT });
+
+      expect(actualIdentity.kind).toBe("origin");
+      expect(actualIdentity.source).toBe("github.com/wuxie233/micode");
+      expect(unrelatedIdentity.projectId).not.toBe(actualIdentity.projectId);
+      expect(promoted).toContain("## Project memory promoted");
+      expect(promoted).toContain(DECISION);
+      expect(actualHits).toContain(DECISION);
+      expect(actualHits).toContain(POINTER);
+      expect(unrelatedHits).toContain("No project memory entries");
+      expect(unrelatedHits).not.toContain(DECISION);
+      expect(await memory.countEntries(actualIdentity.projectId)).toBe(1);
+      expect(await memory.countEntries(unrelatedIdentity.projectId)).toBe(0);
+    },
+    TEST_TIMEOUT_MS,
+  );
+});

--- a/tests/integration/project-memory-maintenance-nonblocking.test.ts
+++ b/tests/integration/project-memory-maintenance-nonblocking.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -11,26 +11,20 @@ import {
   type ProjectMemoryMaintenanceScheduler,
 } from "@/lifecycle";
 import type { LifecycleRunner, RunResult } from "@/lifecycle/runner";
-import { createProjectMemoryStore } from "@/project-memory";
-import type { ScheduleMaintenanceInput } from "@/project-memory/maintenance/scheduler";
-import { resetProjectMemoryRuntimeForTest, setProjectMemoryStoreForTest } from "@/tools/project-memory/runtime";
+import type { ScheduleMaintenanceInput, ScheduleMaintenanceOutcome } from "@/project-memory/maintenance/scheduler";
 import { config } from "@/utils/config";
-import { resolveProjectId } from "@/utils/project-id";
 
-const PREFIX = "micode-memory-lifecycle-";
+const PREFIX = "micode-maintenance-nonblocking-";
 const OWNER = "Wuxie233";
 const REPO = "micode";
 const REPO_NAME = `${OWNER}/${REPO}`;
 const ORIGIN = `https://github.com/${REPO_NAME}.git`;
 const ISSUE_NUMBER = 1;
 const ISSUE_URL = `https://github.com/${REPO_NAME}/issues/${ISSUE_NUMBER}`;
+const SUMMARY = "Lifecycle maintenance nonblocking";
+const PLAN_POINTER = "thoughts/shared/plans/issue-1.md";
+const LEDGER_POINTER = "thoughts/ledgers/issue-1.md";
 const SHA = "abc123def456";
-const SUMMARY = "Lifecycle memory finish";
-const LEDGER_POINTER = join("thoughts", "ledgers", "CONTINUITY.md");
-const LEDGER_QUERY = "durable";
-const STATUS_ACTIVE = "active";
-const COMMIT_SCOPE = "memory";
-const COMMIT_SUMMARY = "record lifecycle memory";
 const EMPTY_OUTPUT = "";
 const OK_EXIT_CODE = 0;
 const GH_ISSUE = "issue";
@@ -42,9 +36,9 @@ const GH_EDIT = "edit";
 const GIT_REMOTE = "remote";
 const GIT_GET_URL = "get-url";
 const GIT_ORIGIN = "origin";
-const GIT_REV_PARSE = "rev-parse";
-const GIT_HEAD = "HEAD";
 const GH_CLOSE_ARGS = [GH_ISSUE, GH_CLOSE, String(ISSUE_NUMBER)] as const;
+const SCHEDULER_ERROR = "scheduler exploded";
+const WARNING_MARKER = "lifecycle.project-memory-maintenance";
 
 interface RunnerCall {
   readonly bin: "git" | "gh";
@@ -87,7 +81,7 @@ const createRunner = (): FakeRunner => {
     git: async (args, options) => {
       calls.push({ bin: "git", args, cwd: options?.cwd });
       if (isArgs(args, [GIT_REMOTE, GIT_GET_URL, GIT_ORIGIN])) return createRun(`${ORIGIN}\n`);
-      if (isArgs(args, [GIT_REV_PARSE, GIT_HEAD])) return createRun(`${SHA}\n`);
+      if (isArgs(args, ["rev-parse", "HEAD"])) return createRun(`${SHA}\n`);
       return createRun();
     },
     gh: async (args, options) => {
@@ -99,6 +93,12 @@ const createRunner = (): FakeRunner => {
       return createRun();
     },
   };
+};
+
+const createRejectingScheduler = (): ProjectMemoryMaintenanceScheduler => {
+  return mock(async (_input: ScheduleMaintenanceInput): Promise<ScheduleMaintenanceOutcome> => {
+    throw new Error(SCHEDULER_ERROR);
+  });
 };
 
 let root: string;
@@ -131,49 +131,36 @@ beforeEach(async () => {
   setMaintenanceFlags(true, true);
 });
 
-afterEach(async () => {
+afterEach(() => {
   setMaintenanceFlags(originalMaintenanceEnabled, originalTerminalTriggerEnabled);
-  await resetProjectMemoryRuntimeForTest();
   rmSync(root, { recursive: true, force: true });
 });
 
-async function useMemory() {
-  const memory = createProjectMemoryStore({ dbDir: join(root, "memory") });
-  await memory.initialize();
-  setProjectMemoryStoreForTest(memory);
-  return memory;
+function scheduledInput(scheduler: ProjectMemoryMaintenanceScheduler): ScheduleMaintenanceInput {
+  return (scheduler as unknown as { mock: { calls: [ScheduleMaintenanceInput][] } }).mock.calls[0][0];
 }
 
-describe("project memory lifecycle finish E2E", () => {
-  it("keeps lifecycle finish successful without auto-promoting lifecycle memory", async () => {
-    const memory = await useMemory();
+describe("project memory maintenance nonblocking finish integration", () => {
+  it("keeps lifecycle finish merged, closed, and cleaned when terminal maintenance rejects", async () => {
     const runner = createRunner();
-    let schedulerInput: ScheduleMaintenanceInput | null = null;
-    const scheduler: ProjectMemoryMaintenanceScheduler = async (input) => {
-      schedulerInput = input;
-      return { scheduled: true, note: null };
-    };
+    const scheduler = createRejectingScheduler();
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
     const handle = createLifecycleStore({ runner, worktreesRoot, cwd, baseDir, maintenanceScheduler: scheduler });
-    const started = await handle.start({
-      summary: SUMMARY,
-      goals: ["Finish lifecycle without direct memory promotion"],
-      constraints: ["Use temp memory store"],
-      ownerLogin: OWNER,
-      repo: REPO,
-    });
+    const started = await handle.start({ summary: SUMMARY, goals: ["finish lifecycle"], constraints: [] });
+    await handle.recordArtifact(started.issueNumber, ARTIFACT_KINDS.PLAN, PLAN_POINTER);
     await handle.recordArtifact(started.issueNumber, ARTIFACT_KINDS.LEDGER, LEDGER_POINTER);
 
-    const committed = await handle.commit(ISSUE_NUMBER, {
-      scope: COMMIT_SCOPE,
-      summary: COMMIT_SUMMARY,
-      push: false,
-    });
-    const outcome = await handle.finish(ISSUE_NUMBER, { mergeStrategy: "local-merge", waitForChecks: false });
-    const identity = await resolveProjectId(cwd);
-    const hits = await memory.searchEntries(identity.projectId, LEDGER_QUERY, { status: STATUS_ACTIVE, limit: 5 });
+    let thrown: unknown = null;
+    const outcome = await handle
+      .finish(ISSUE_NUMBER, { mergeStrategy: "local-merge", waitForChecks: false })
+      .catch((error) => {
+        thrown = error;
+        return null;
+      });
     const record = await handle.load(ISSUE_NUMBER);
+    const input = scheduledInput(scheduler);
 
-    expect(committed).toEqual({ committed: true, sha: SHA, pushed: false, retried: false, note: null });
+    expect(thrown).toBeNull();
     expect(outcome).toEqual({
       merged: true,
       prUrl: null,
@@ -186,25 +173,23 @@ describe("project memory lifecycle finish E2E", () => {
       note: null,
     });
     expect(record?.state).toBe(LIFECYCLE_STATES.CLEANED);
-    expect(record?.artifacts[ARTIFACT_KINDS.COMMIT]).toEqual([SHA]);
-    expect(record?.notes).toEqual([]);
     expect(runner.calls.some((call) => call.bin === "gh" && isArgs(call.args, GH_CLOSE_ARGS))).toBe(true);
     expect(runner.edits.at(-1)).toContain("state: cleaned");
-    expect(hits).toEqual([]);
-    expect(await memory.countEntries(identity.projectId)).toBe(0);
-    expect(await memory.countSources(identity.projectId)).toBe(0);
-    expect(schedulerInput).toEqual({
+    expect(scheduler).toHaveBeenCalledTimes(1);
+    expect(input).toEqual({
       reason: "terminal",
       triggeredBy: "lifecycle.finish",
       directory: cwd,
       sourcePointers: [
         "issue/1",
         expect.stringContaining("issue/1-"),
+        PLAN_POINTER,
         LEDGER_POINTER,
-        SHA,
-        expect.stringContaining("/worktrees/issue-1-lifecycle-memory-finish"),
+        expect.stringContaining("/worktrees/issue-1-lifecycle-maintenance-nonblocking"),
         "outcome/merged",
       ],
     });
+    expect(warnSpy).toHaveBeenCalledWith(`[${WARNING_MARKER}] schedule failed: ${SCHEDULER_ERROR}`);
+    warnSpy.mockRestore();
   });
 });

--- a/tests/integration/project-memory-worktree.test.ts
+++ b/tests/integration/project-memory-worktree.test.ts
@@ -10,7 +10,7 @@ import { createProjectMemoryStore, type ProjectMemoryStore } from "@/project-mem
 import { createProjectMemoryLookupTool } from "@/tools/project-memory/lookup";
 import { createProjectMemoryPromoteTool } from "@/tools/project-memory/promote";
 import { resetProjectMemoryRuntimeForTest, setProjectMemoryStoreForTest } from "@/tools/project-memory/runtime";
-import { resolveProjectId } from "@/utils/project-id";
+import { normalizeProjectOrigin, projectIdForSource, resolveProjectId } from "@/utils/project-id";
 
 const ROOT_PREFIX = "project-memory-worktree-";
 const ORIGIN_URL = "https://github.com/Wuxie233/micode.git";
@@ -29,6 +29,8 @@ const DECISION = "Worktree durability survives worktree deletion through shared 
 const QUERY = "worktree durability";
 const LOOKUP_LIMIT = 5;
 const EXPECTED_ENTRY_COUNT = 1;
+const EXPECTED_ORIGIN_SOURCE = normalizeProjectOrigin(ORIGIN_URL);
+const EXPECTED_PROJECT_ID = projectIdForSource(EXPECTED_ORIGIN_SOURCE);
 
 interface FixturePaths {
   readonly repo: string;
@@ -106,9 +108,9 @@ async function promoteFrom(directory: string): Promise<string> {
   });
 }
 
-async function lookupFrom(directory: string): Promise<string> {
+async function lookupFrom(directory: string, args: Record<string, unknown> = {}): Promise<string> {
   const toolDef = createProjectMemoryLookupTool(createContext(directory)).project_memory_lookup;
-  return executeTool(toolDef, { query: QUERY, limit: LOOKUP_LIMIT });
+  return executeTool(toolDef, { query: QUERY, limit: LOOKUP_LIMIT, ...args });
 }
 
 describe("project memory worktree durability", () => {
@@ -135,6 +137,9 @@ describe("project memory worktree durability", () => {
     expect(paths.store.startsWith(paths.right)).toBe(false);
     expect(leftIdentity.kind).toBe("origin");
     expect(rightIdentity.kind).toBe("origin");
+    expect(leftIdentity.source).toBe(EXPECTED_ORIGIN_SOURCE);
+    expect(rightIdentity.source).toBe(EXPECTED_ORIGIN_SOURCE);
+    expect(leftIdentity.projectId).toBe(EXPECTED_PROJECT_ID);
     expect(rightIdentity.projectId).toBe(leftIdentity.projectId);
     expect(rightIdentity.source).toBe(leftIdentity.source);
 
@@ -153,5 +158,15 @@ describe("project memory worktree durability", () => {
     const afterDelete = await lookupFrom(paths.right);
     expect(afterDelete).toContain(DECISION);
     expect(afterDelete).toContain(POINTER);
+
+    const outsideDirectory = join(root, "outside-project");
+    mkdirSync(outsideDirectory);
+    const outsideIdentity = await resolveProjectId(outsideDirectory);
+    expect(outsideIdentity.kind).toBe("path");
+    expect(outsideIdentity.projectId).not.toBe(leftIdentity.projectId);
+
+    const explicitOriginLookup = await lookupFrom(outsideDirectory, { project_origin: ORIGIN_URL });
+    expect(explicitOriginLookup).toContain(DECISION);
+    expect(explicitOriginLookup).toContain(POINTER);
   });
 });

--- a/tests/lifecycle/project-memory-boundary.test.ts
+++ b/tests/lifecycle/project-memory-boundary.test.ts
@@ -3,6 +3,24 @@ import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 const SCAN_DIRS = ["src/lifecycle", "src/tools/lifecycle"];
+const MAINTENANCE_DIR = "src/project-memory/maintenance";
+
+const PROJECT_MEMORY_PROMOTE_TOOL_PATTERN = /\bproject_memory_promote\b/u;
+const PROMOTE_MARKDOWN_CALL_PATTERN = /\bpromoteMarkdown\s*\(/u;
+const PROMOTE_MARKDOWN_IMPORT_PATTERN = /import\s+[\s\S]*\bpromoteMarkdown\b[\s\S]*from\s+["']@\/project-memory["']/u;
+const FORBIDDEN_LIFECYCLE_MAINTENANCE_PATTERNS = [
+  /\brunProjectMemoryMaintenance\b/u,
+  /from\s+["']@\/project-memory\/maintenance\/(?:classifier|worker)["']/u,
+  /from\s+["']\.\.\/project-memory\/maintenance\/(?:classifier|worker)["']/u,
+  /from\s+["']\.\.\/\.\.\/project-memory\/maintenance\/(?:classifier|worker)["']/u,
+] as const;
+const FORBIDDEN_PROJECT_MEMORY_MAINTENANCE_PATTERNS = [
+  /\batlas_lookup\b/u,
+  /atlas-compiler/u,
+  /writeFileSync\(\s*["']atlas/u,
+  /\bproject_memory_promote\b/u,
+  /\bproject_memory_forget\b/u,
+] as const;
 
 const walk = (dir: string, out: string[]): void => {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -12,11 +30,7 @@ const walk = (dir: string, out: string[]): void => {
   }
 };
 
-const ALLOWED_PROMOTE_SITES = new Set([
-  // Single gated call site that respects config.projectMemory.promoteOnLifecycleFinish.
-  // promoteFinishedRecord is the ONLY function in lifecycle that may call promoteMarkdown.
-  "src/lifecycle/index.ts",
-]);
+const ALLOWED_PROMOTE_SITES = new Set<string>();
 
 describe("lifecycle does not auto-write Project Memory", () => {
   for (const dir of SCAN_DIRS) {
@@ -41,19 +55,72 @@ describe("lifecycle does not auto-write Project Memory", () => {
     });
   }
 
+  it("lifecycle has no direct Project Memory promotion call sites", () => {
+    const files: string[] = [];
+    for (const dir of SCAN_DIRS) walk(dir, files);
+    expect(files.length).toBeGreaterThan(0);
+
+    const promoteMarkdownCallSites: string[] = [];
+    const promoteMarkdownImportSites: string[] = [];
+
+    for (const f of files) {
+      const src = readFileSync(f, "utf8");
+      if (PROMOTE_MARKDOWN_CALL_PATTERN.test(src)) promoteMarkdownCallSites.push(f);
+      if (PROMOTE_MARKDOWN_IMPORT_PATTERN.test(src)) promoteMarkdownImportSites.push(f);
+      expect({ file: f, promoteTool: PROJECT_MEMORY_PROMOTE_TOOL_PATTERN.test(src) }).toEqual({
+        file: f,
+        promoteTool: false,
+      });
+    }
+
+    expect(new Set(promoteMarkdownCallSites)).toEqual(ALLOWED_PROMOTE_SITES);
+    expect(new Set(promoteMarkdownImportSites)).toEqual(ALLOWED_PROMOTE_SITES);
+  });
+
+  it("lifecycle may schedule Project Memory maintenance but not import worker internals", () => {
+    const files: string[] = [];
+    for (const dir of SCAN_DIRS) walk(dir, files);
+    expect(files.length).toBeGreaterThan(0);
+
+    for (const f of files) {
+      const src = readFileSync(f, "utf8");
+      for (const pat of FORBIDDEN_LIFECYCLE_MAINTENANCE_PATTERNS) {
+        expect({ file: f, matched: pat.toString(), hit: pat.test(src) }).toEqual({
+          file: f,
+          matched: pat.toString(),
+          hit: false,
+        });
+      }
+    }
+  });
+
+  it("Project Memory maintenance does not write Atlas or call MCP memory tools", () => {
+    const files: string[] = [];
+    walk(MAINTENANCE_DIR, files);
+    expect(files.length).toBeGreaterThan(0);
+
+    for (const f of files) {
+      const src = readFileSync(f, "utf8");
+      for (const pat of FORBIDDEN_PROJECT_MEMORY_MAINTENANCE_PATTERNS) {
+        expect({ file: f, matched: pat.toString(), hit: pat.test(src) }).toEqual({
+          file: f,
+          matched: pat.toString(),
+          hit: false,
+        });
+      }
+    }
+  });
+
   it("default config.projectMemory.promoteOnLifecycleFinish is false", () => {
     // This guards the default-flip from being silently reverted.
     const configSrc = readFileSync("src/utils/config.ts", "utf8");
     expect(configSrc).toMatch(/promoteOnLifecycleFinish:\s*false/);
   });
 
-  it("the allowed call site is gated by the config flag", () => {
-    // promoteFinishedRecord in src/lifecycle/index.ts MUST guard with the config flag.
-    // Without the guard, flipping the default does nothing.
+  it("the legacy promoteOnLifecycleFinish flag is not used by lifecycle finish", () => {
     const indexSrc = readFileSync("src/lifecycle/index.ts", "utf8");
-    expect(indexSrc).toContain("config.projectMemory.promoteOnLifecycleFinish");
-    // Check that the check appears in a short-circuit return position
-    expect(indexSrc).toMatch(/if\s*\([^)]*!config\.projectMemory\.promoteOnLifecycleFinish[^)]*\)\s*return/);
+    expect(indexSrc).not.toContain("promoteOnLifecycleFinish");
+    expect(indexSrc).not.toContain("promoteFinishedRecord");
   });
 
   it("agents Atlas Shared Mental Model section mirrors Project Memory boundary", () => {

--- a/tests/lifecycle/project-memory-maintenance-trigger.test.ts
+++ b/tests/lifecycle/project-memory-maintenance-trigger.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { $ } from "bun";
+
+import { ARTIFACT_KINDS, createLifecycleStore, type ProjectMemoryMaintenanceScheduler } from "@/lifecycle";
+import { JOURNAL_EVENT_KINDS } from "@/lifecycle/journal/types";
+import type { LifecycleRunner, RunResult } from "@/lifecycle/runner";
+import type { ScheduleMaintenanceInput, ScheduleMaintenanceOutcome } from "@/project-memory/maintenance/scheduler";
+import { config } from "@/utils/config";
+
+const PREFIX = "micode-lifecycle-maintenance-";
+const OWNER = "Wuxie233";
+const REPO = "micode";
+const REPO_NAME = `${OWNER}/${REPO}`;
+const ORIGIN = `https://github.com/${REPO_NAME}.git`;
+const ISSUE_NUMBER = 1;
+const ISSUE_URL = `https://github.com/${REPO_NAME}/issues/${ISSUE_NUMBER}`;
+const PLAN_POINTER = "thoughts/shared/plans/issue-1.md";
+const LEDGER_POINTER = "thoughts/ledgers/issue-1.md";
+const EMPTY_OUTPUT = "";
+const OK_EXIT_CODE = 0;
+const FAILURE_EXIT_CODE = 1;
+
+interface RunnerCall {
+  readonly bin: "git" | "gh";
+  readonly args: readonly string[];
+  readonly cwd?: string;
+}
+
+interface FakeRunner extends LifecycleRunner {
+  readonly calls: readonly RunnerCall[];
+}
+
+interface RunnerOptions {
+  readonly failMerge?: boolean;
+}
+
+const createRun = (stdout = EMPTY_OUTPUT, exitCode = OK_EXIT_CODE): RunResult => ({
+  stdout,
+  stderr: EMPTY_OUTPUT,
+  exitCode,
+});
+
+const createRepoView = (): string =>
+  JSON.stringify({
+    nameWithOwner: REPO_NAME,
+    isFork: true,
+    parent: { nameWithOwner: "vtemian/micode", url: "https://github.com/vtemian/micode" },
+    owner: { login: OWNER },
+    viewerPermission: "ADMIN",
+    hasIssuesEnabled: true,
+  });
+
+const isArgs = (args: readonly string[], expected: readonly string[]): boolean => {
+  return expected.every((value, index) => args[index] === value);
+};
+
+const createRunner = (options: RunnerOptions = {}): FakeRunner => {
+  const calls: RunnerCall[] = [];
+
+  return {
+    calls,
+    git: async (args, gitOptions) => {
+      calls.push({ bin: "git", args, cwd: gitOptions?.cwd });
+      if (isArgs(args, ["remote", "get-url", "origin"])) return createRun(`${ORIGIN}\n`);
+      if (options.failMerge && isArgs(args, ["merge", "--no-ff"])) return createRun(EMPTY_OUTPUT, FAILURE_EXIT_CODE);
+      return createRun();
+    },
+    gh: async (args, ghOptions) => {
+      calls.push({ bin: "gh", args, cwd: ghOptions?.cwd });
+      if (isArgs(args, ["repo", "view"])) return createRun(createRepoView());
+      if (isArgs(args, ["issue", "create"])) return createRun(`${ISSUE_URL}\n`);
+      if (isArgs(args, ["issue", "view"])) return createRun(JSON.stringify({ body: "## Context\n\nExisting body" }));
+      return createRun();
+    },
+  };
+};
+
+const createMaintenanceScheduler = (
+  implementation?: ProjectMemoryMaintenanceScheduler,
+): ProjectMemoryMaintenanceScheduler => {
+  return mock(
+    implementation ??
+      (async (): Promise<ScheduleMaintenanceOutcome> => ({ scheduled: true, reason: "scheduled", warnings: [] })),
+  );
+};
+
+let root: string;
+let cwd: string;
+let baseDir: string;
+let worktreesRoot: string;
+let originalMaintenanceEnabled: boolean;
+let originalTerminalTriggerEnabled: boolean;
+
+function setMaintenanceFlags(enabled: boolean, terminalEnabled = enabled): void {
+  (
+    config.projectMemory as { maintenanceEnabled: boolean; maintenanceTerminalTriggerEnabled: boolean }
+  ).maintenanceEnabled = enabled;
+  (
+    config.projectMemory as { maintenanceEnabled: boolean; maintenanceTerminalTriggerEnabled: boolean }
+  ).maintenanceTerminalTriggerEnabled = terminalEnabled;
+}
+
+beforeEach(async () => {
+  root = mkdtempSync(join(tmpdir(), PREFIX));
+  cwd = join(root, "repo");
+  baseDir = join(root, "records");
+  worktreesRoot = join(root, "worktrees");
+  mkdirSync(cwd, { recursive: true });
+  mkdirSync(worktreesRoot, { recursive: true });
+  await $`git init -q`.cwd(cwd);
+  await $`git remote add origin ${ORIGIN}`.cwd(cwd);
+  originalMaintenanceEnabled = config.projectMemory.maintenanceEnabled;
+  originalTerminalTriggerEnabled = config.projectMemory.maintenanceTerminalTriggerEnabled;
+  setMaintenanceFlags(true, true);
+});
+
+afterEach(() => {
+  setMaintenanceFlags(originalMaintenanceEnabled, originalTerminalTriggerEnabled);
+  rmSync(root, { recursive: true, force: true });
+});
+
+async function startLifecycle(
+  maintenanceScheduler: ProjectMemoryMaintenanceScheduler,
+  runner: FakeRunner = createRunner(),
+) {
+  const handle = createLifecycleStore({ runner, worktreesRoot, cwd, baseDir, maintenanceScheduler });
+  const started = await handle.start({ summary: "Lifecycle maintenance", goals: [], constraints: [] });
+  await handle.recordArtifact(started.issueNumber, ARTIFACT_KINDS.PLAN, PLAN_POINTER);
+  await handle.recordArtifact(started.issueNumber, ARTIFACT_KINDS.LEDGER, LEDGER_POINTER);
+  return { handle, runner };
+}
+
+function scheduledInput(scheduler: ProjectMemoryMaintenanceScheduler): ScheduleMaintenanceInput {
+  return (scheduler as unknown as { mock: { calls: [ScheduleMaintenanceInput][] } }).mock.calls[0][0];
+}
+
+describe("lifecycle terminal project-memory maintenance trigger", () => {
+  it("schedules terminal maintenance once for merged finish with source pointers", async () => {
+    const scheduler = createMaintenanceScheduler();
+    const { handle } = await startLifecycle(scheduler);
+
+    const outcome = await handle.finish(ISSUE_NUMBER, { mergeStrategy: "local-merge", waitForChecks: false });
+    const input = scheduledInput(scheduler);
+
+    expect(outcome.merged).toBe(true);
+    expect(scheduler).toHaveBeenCalledTimes(1);
+    expect(input).toEqual({
+      reason: "terminal",
+      triggeredBy: "lifecycle.finish",
+      directory: cwd,
+      sourcePointers: [
+        "issue/1",
+        expect.stringContaining("issue/1-"),
+        PLAN_POINTER,
+        LEDGER_POINTER,
+        expect.stringContaining("/worktrees/issue-1-lifecycle-maintenance"),
+        "outcome/merged",
+      ],
+    });
+  });
+
+  it("keeps finish outcome successful when scheduler rejects", async () => {
+    const scheduler = createMaintenanceScheduler(async () => {
+      throw new Error("scheduler exploded");
+    });
+    const { handle } = await startLifecycle(scheduler);
+
+    const outcome = await handle.finish(ISSUE_NUMBER, { mergeStrategy: "local-merge", waitForChecks: false });
+
+    expect(outcome.merged).toBe(true);
+    expect(scheduler).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not schedule when the terminal maintenance trigger flag is false", async () => {
+    setMaintenanceFlags(true, false);
+    const scheduler = createMaintenanceScheduler();
+    const { handle } = await startLifecycle(scheduler);
+
+    const outcome = await handle.finish(ISSUE_NUMBER, { mergeStrategy: "local-merge", waitForChecks: false });
+
+    expect(outcome.merged).toBe(true);
+    expect(scheduler).not.toHaveBeenCalled();
+  });
+
+  it("does not schedule non-merged non-blocked finish outcomes", async () => {
+    const scheduler = createMaintenanceScheduler();
+    const runner = createRunner({ failMerge: true });
+    const { handle } = await startLifecycle(scheduler, runner);
+
+    const outcome = await handle.finish(ISSUE_NUMBER, { mergeStrategy: "local-merge", waitForChecks: false });
+
+    expect(outcome.merged).toBe(false);
+    expect(scheduler).not.toHaveBeenCalled();
+  });
+
+  it("schedules terminal maintenance for executor-blocked terminal outcomes", async () => {
+    const scheduler = createMaintenanceScheduler();
+    const { handle } = await startLifecycle(scheduler);
+    await handle.recordExecutorEvent({
+      issueNumber: ISSUE_NUMBER,
+      kind: JOURNAL_EVENT_KINDS.REVIEW_COMPLETED,
+      taskId: "task-1",
+      summary: "review blocked",
+      reviewOutcome: "blocked",
+    });
+
+    const outcome = await handle.finish(ISSUE_NUMBER, { mergeStrategy: "local-merge", waitForChecks: false });
+    const input = scheduledInput(scheduler);
+
+    expect(outcome.merged).toBe(false);
+    expect(outcome.note).toBe("executor_blocked: task-1");
+    expect(scheduler).toHaveBeenCalledTimes(1);
+    expect(input.sourcePointers).toEqual([
+      "issue/1",
+      expect.stringContaining("issue/1-"),
+      PLAN_POINTER,
+      LEDGER_POINTER,
+      expect.stringContaining("/worktrees/issue-1-lifecycle-maintenance"),
+      "outcome/executor_blocked",
+    ]);
+  });
+});

--- a/tests/lifecycle/promote-on-finish.test.ts
+++ b/tests/lifecycle/promote-on-finish.test.ts
@@ -21,20 +21,7 @@ const EMPTY_OUTPUT = "";
 const OK_EXIT_CODE = 0;
 const FAILURE_EXIT_CODE = 1;
 const LEDGER_POINTER = join("thoughts", "ledgers", "CONTINUITY.md");
-const ISSUE_POINTER = "issue/1";
 const PROMOTION_FAILURE = "promotion write failed";
-const ISSUE_REQUEST_SUMMARY = "Improve project memory promotion quality so issue bodies become useful entries.";
-const ISSUE_GOAL_SUMMARIES = [
-  "Parse lifecycle sections deterministically",
-  "Avoid collapsing the body into a single ## Request note",
-] as const;
-const ISSUE_CONSTRAINT_SUMMARIES = ["Keep promotion best-effort and non-blocking"] as const;
-const EXPECTED_ISSUE_NOTE_SUMMARIES = [
-  ISSUE_REQUEST_SUMMARY,
-  ...ISSUE_GOAL_SUMMARIES,
-  ...ISSUE_CONSTRAINT_SUMMARIES,
-] as const;
-const ISSUE_BODY_SEARCH_LIMIT = 20;
 const LIFECYCLE_PROMOTE_TEST_TIMEOUT_MS = 20_000;
 const LEDGER_MARKDOWN = [
   "## Decisions",
@@ -182,7 +169,7 @@ async function startWithLedger(handle: LifecycleHandle, markdown = LEDGER_MARKDO
 
 describe("lifecycle finish project-memory promotion", () => {
   it(
-    "promotes merged lifecycle ledger entries as active lifecycle sources",
+    "does not promote merged lifecycle ledger entries even when legacy flag is true",
     async () => {
       setPromoteOnLifecycleFinish(true);
       const memory = await useMemory();
@@ -197,31 +184,31 @@ describe("lifecycle finish project-memory promotion", () => {
       const record = await handle.load(ISSUE_NUMBER);
 
       expect(outcome.merged).toBe(true);
-      expect(await memory.countEntries(identity.projectId)).toBe(2);
-      expect(hits[0]?.entry.status).toBe("active");
-      expect(sources[0]?.kind).toBe("lifecycle");
-      expect(sources[0]?.pointer).toBe(ISSUE_POINTER);
-      expect(record?.notes).toContain("memory_promoted: 2 entries");
+      expect(await memory.countEntries(identity.projectId)).toBe(0);
+      expect(hits).toHaveLength(0);
+      expect(sources).toHaveLength(0);
+      expect(record?.notes.some((note) => note.startsWith("memory_"))).toBe(false);
     },
     LIFECYCLE_PROMOTE_TEST_TIMEOUT_MS,
   );
 
   it(
-    "promotes lifecycle issue body sections as meaningful notes when no ledger exists",
+    "does not promote lifecycle issue body sections when no ledger exists",
     async () => {
       setPromoteOnLifecycleFinish(true);
       const issueBody = [
         "## Request",
         "",
-        ISSUE_REQUEST_SUMMARY,
+        "Improve project memory promotion quality so issue bodies become useful entries.",
         "",
         "## Goals",
         "",
-        ...ISSUE_GOAL_SUMMARIES.map((summary) => `- ${summary}`),
+        "- Parse lifecycle sections deterministically",
+        "- Avoid collapsing the body into a single ## Request note",
         "",
         "## Constraints",
         "",
-        ...ISSUE_CONSTRAINT_SUMMARIES.map((summary) => `- ${summary}`),
+        "- Keep promotion best-effort and non-blocking",
       ].join("\n");
       const memory = await useMemory();
       const runner = createRunner({ issueBody });
@@ -236,28 +223,11 @@ describe("lifecycle finish project-memory promotion", () => {
 
       const outcome = await handle.finish(ISSUE_NUMBER, { mergeStrategy: "local-merge", waitForChecks: false });
       const identity = await resolveProjectId(cwd);
-      const found = await Promise.all(
-        EXPECTED_ISSUE_NOTE_SUMMARIES.map(async (summary) => {
-          const hits = await memory.searchEntries(identity.projectId, summary, {
-            status: "active",
-            type: "note",
-            limit: ISSUE_BODY_SEARCH_LIMIT,
-          });
-          return hits.find((hit) => hit.entry.summary === summary)?.entry;
-        }),
-      );
-      const entries = found.flatMap((entry) => (entry ? [entry] : []));
-      const titles = entries.map((entry) => entry.title);
-      const summaries = entries.map((entry) => entry.summary);
+      const record = await handle.load(ISSUE_NUMBER);
 
       expect(outcome.merged).toBe(true);
-      expect(await memory.countEntries(identity.projectId)).toBe(EXPECTED_ISSUE_NOTE_SUMMARIES.length);
-      expect(entries).toHaveLength(EXPECTED_ISSUE_NOTE_SUMMARIES.length);
-      expect(entries.every((entry) => entry.type === "note")).toBe(true);
-      expect(titles.every((title) => !title.startsWith("#"))).toBe(true);
-      expect(titles[0]).toBe(ISSUE_REQUEST_SUMMARY);
-      expect(titles).toEqual(EXPECTED_ISSUE_NOTE_SUMMARIES);
-      expect(summaries).toEqual(EXPECTED_ISSUE_NOTE_SUMMARIES);
+      expect(await memory.countEntries(identity.projectId)).toBe(0);
+      expect(record?.notes.some((note) => note.startsWith("memory_"))).toBe(false);
     },
     LIFECYCLE_PROMOTE_TEST_TIMEOUT_MS,
   );
@@ -278,7 +248,7 @@ describe("lifecycle finish project-memory promotion", () => {
     expect(record?.notes.some((note) => note.startsWith("memory_"))).toBe(false);
   });
 
-  it("keeps merged finish outcomes when promotion fails", async () => {
+  it("keeps merged finish outcomes without touching the promotion store", async () => {
     setPromoteOnLifecycleFinish(true);
     setProjectMemoryStoreForTest(createFailingStore());
     const runner = createRunner();
@@ -289,7 +259,8 @@ describe("lifecycle finish project-memory promotion", () => {
     const record = await handle.load(ISSUE_NUMBER);
 
     expect(outcome.merged).toBe(true);
-    expect(record?.notes).toContain(`memory_promotion_failed: ${PROMOTION_FAILURE}`);
+    expect(record?.notes).not.toContain(`memory_promotion_failed: ${PROMOTION_FAILURE}`);
+    expect(record?.notes.some((note) => note.startsWith("memory_"))).toBe(false);
   });
 
   it("does not promote project memory by default on merged finish", async () => {

--- a/tests/project-memory/identity.test.ts
+++ b/tests/project-memory/identity.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import {
+  assertMaintenanceProjectIdentity,
+  assertWritableProjectIdentity,
+  resolveProjectMemoryIdentity,
+} from "@/project-memory/identity";
+import type { ProjectRegistry, ProjectRegistryRecord } from "@/project-memory/registry";
+import { normalizeRegistryRecord } from "@/project-memory/registry";
+import { normalizeProjectOrigin, projectIdForSource } from "@/utils/project-id";
+
+const UPDATED_AT = 1_234;
+const EXPECTED_TWO = 2;
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "pm-identity-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function testRecord(record: Omit<ProjectRegistryRecord, "updatedAt">): ProjectRegistryRecord {
+  return normalizeRegistryRecord({ ...record, updatedAt: UPDATED_AT });
+}
+
+function registry(records: readonly ProjectRegistryRecord[]): ProjectRegistry {
+  const normalized = records.map((record) => normalizeRegistryRecord(record));
+  return {
+    load: async () => normalized,
+    upsert: async () => undefined,
+    findByAlias: async (alias) => {
+      const normalizedAlias = alias.trim().toLowerCase();
+      return normalized.filter((record) => record.aliases.includes(normalizedAlias));
+    },
+    findByOrigin: async (origin) => {
+      const normalizedOrigin = normalizeProjectOrigin(origin);
+      return normalized.filter((record) => record.origin === normalizedOrigin);
+    },
+    findByWorktree: async (worktree) => {
+      const normalizedWorktree = resolve(worktree);
+      return normalized.filter((record) => record.worktrees.includes(normalizedWorktree));
+    },
+  };
+}
+
+describe("resolveProjectMemoryIdentity", () => {
+  it("prioritizes an explicit exact projectId over session and lifecycle targets", async () => {
+    const resolution = await resolveProjectMemoryIdentity({
+      directory: dir,
+      explicitTarget: { projectId: "project-explicit" },
+      sessionTarget: { projectId: "project-session" },
+      lifecycleTarget: { projectId: "project-lifecycle" },
+    });
+
+    expect(resolution.status).toBe("resolved");
+    expect(resolution.source).toBe("explicit");
+    expect(resolution.identity?.projectId).toBe("project-explicit");
+  });
+
+  it("normalizes origins and hashes the exact normalized origin without fuzzy matching", async () => {
+    const normalized = "github.com/wuxie233/micode";
+
+    const resolution = await resolveProjectMemoryIdentity({
+      directory: dir,
+      explicitTarget: { origin: "git@github.com:Wuxie233/micode.git" },
+      registry: registry([
+        testRecord({
+          projectId: "project-other",
+          origin: "github.com/wuxie233/micode-extra",
+          aliases: [],
+          worktrees: [],
+        }),
+      ]),
+    });
+
+    expect(resolution.status).toBe("resolved");
+    expect(resolution.identity).toEqual({
+      projectId: projectIdForSource(normalized),
+      kind: "origin",
+      source: normalized,
+    });
+  });
+
+  it("blocks an explicit alias that has zero exact registry matches", async () => {
+    const resolution = await resolveProjectMemoryIdentity({
+      directory: dir,
+      explicitTarget: { alias: "mico" },
+      sessionTarget: { projectId: "project-session" },
+      registry: registry([testRecord({ projectId: "project-one", aliases: ["micode"], worktrees: [] })]),
+    });
+
+    expect(resolution.status).toBe("blocked");
+    expect(resolution.identity).toBeUndefined();
+    expect(() => assertWritableProjectIdentity(resolution)).toThrow(/blocked/i);
+  });
+
+  it("falls through when a non-explicit alias has zero registry matches", async () => {
+    const resolution = await resolveProjectMemoryIdentity({
+      directory: dir,
+      sessionTarget: { alias: "missing" },
+      lifecycleTarget: { projectId: "project-lifecycle" },
+      registry: registry([]),
+    });
+
+    expect(resolution.status).toBe("resolved");
+    expect(resolution.source).toBe("lifecycle");
+    expect(resolution.identity?.projectId).toBe("project-lifecycle");
+  });
+
+  it("returns ambiguous candidates and blocks writes when registry lookup has multiple matches", async () => {
+    const resolution = await resolveProjectMemoryIdentity({
+      directory: dir,
+      explicitTarget: { alias: "micode" },
+      registry: registry([
+        testRecord({ projectId: "project-one", aliases: ["micode"], worktrees: [] }),
+        testRecord({ projectId: "project-two", aliases: ["micode"], worktrees: [] }),
+      ]),
+    });
+
+    expect(resolution.status).toBe("ambiguous");
+    expect(resolution.candidates?.map((candidate) => candidate.projectId)).toEqual(["project-one", "project-two"]);
+    expect(resolution.candidates).toHaveLength(EXPECTED_TWO);
+    expect(() => assertWritableProjectIdentity(resolution)).toThrow(/ambiguous/i);
+  });
+
+  it("uses registry worktree matches before path-only directory fallback", async () => {
+    const resolution = await resolveProjectMemoryIdentity({
+      directory: dir,
+      registry: registry([testRecord({ projectId: "project-worktree", aliases: [], worktrees: [dir] })]),
+    });
+
+    expect(resolution.status).toBe("resolved");
+    expect(resolution.source).toBe("registry");
+    expect(resolution.identity?.projectId).toBe("project-worktree");
+  });
+
+  it("marks path-only directory fallback as degraded and blocks writes and maintenance by default", async () => {
+    const resolution = await resolveProjectMemoryIdentity({ directory: dir, registry: registry([]) });
+
+    expect(resolution.status).toBe("degraded");
+    expect(resolution.identity?.kind).toBe("path");
+    expect(() => assertWritableProjectIdentity(resolution)).toThrow(/degraded|origin/i);
+    expect(() => assertMaintenanceProjectIdentity(resolution)).toThrow(/degraded|origin/i);
+  });
+});

--- a/tests/project-memory/lookup.test.ts
+++ b/tests/project-memory/lookup.test.ts
@@ -113,7 +113,7 @@ function sensitivities(hits: readonly { readonly entry: Entry }[]): Entry["sensi
 
 describe("lookup", () => {
   it(
-    "applies type, status, and entity filters before ranking through the store",
+    "defaults lookup to active status while preserving type, status, and entity filters",
     async () => {
       const store = createStore();
       await store.initialize();
@@ -135,12 +135,37 @@ describe("lookup", () => {
         limit: LIMIT,
       });
 
-      expect(hitIds(decisions)).toEqual(["entry-decision-active", "entry-decision-tentative"]);
+      expect(hitIds(decisions)).toEqual(["entry-decision-active"]);
       expect(hitIds(active).sort()).toEqual(["entry-decision-active", "entry-risk-active"].sort());
-      expect(hitIds(billing)).toEqual(["entry-decision-tentative"]);
+      expect(hitIds(billing)).toEqual([]);
     },
     LOOKUP_TEST_TIMEOUT_MS,
   );
+
+  it("filters to active entries by default and allows archived or tombstoned lookup explicitly", async () => {
+    const store = createStore();
+    await store.initialize();
+
+    await seedMemory(store, { entry: { id: "entry-active", status: "active" } });
+    await seedMemory(store, { entry: { id: "entry-archived", status: "archived" } });
+    await seedMemory(store, { entry: { id: "entry-tombstoned", status: "tombstoned" } });
+    await seedMemory(store, { entry: { id: "entry-deprecated", status: "deprecated" } });
+    await seedMemory(store, { entry: { id: "entry-superseded", status: "superseded" } });
+
+    const defaultHits = await lookup({ store, identity: IDENTITY, query: "alpha", limit: LIMIT });
+    const archivedHits = await lookup({ store, identity: IDENTITY, query: "alpha", status: "archived", limit: LIMIT });
+    const tombstonedHits = await lookup({
+      store,
+      identity: IDENTITY,
+      query: "alpha",
+      status: "tombstoned",
+      limit: LIMIT,
+    });
+
+    expect(hitIds(defaultHits)).toEqual(["entry-active"]);
+    expect(hitIds(archivedHits)).toEqual(["entry-archived"]);
+    expect(hitIds(tombstonedHits)).toEqual(["entry-tombstoned"]);
+  });
 
   it("applies sensitivity ceiling while leaving uncapped lookup unrestricted", async () => {
     const store = createStore();
@@ -173,15 +198,9 @@ describe("lookup", () => {
     await seedMemory(store, { entry: { id: "entry-tentative", status: "tentative" } });
     await seedMemory(store, { entry: { id: "entry-active", status: "active" } });
 
-    const hits = await lookup({ store, identity: IDENTITY, query: "alpha", limit: LIMIT });
+    const hits = await lookup({ store, identity: IDENTITY, query: "alpha", status: "active", limit: LIMIT });
 
-    expect(hitIds(hits)).toEqual([
-      "entry-active",
-      "entry-tentative",
-      "entry-hypothesis",
-      "entry-superseded",
-      "entry-deprecated",
-    ]);
+    expect(hitIds(hits)).toEqual(["entry-active"]);
   });
 
   it("truncates snippets to the configured maximum", async () => {

--- a/tests/project-memory/maintenance/classifier.test.ts
+++ b/tests/project-memory/maintenance/classifier.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  classifyMaintenanceSnapshot,
+  DEFAULT_MAINTENANCE_STALE_AFTER_MS,
+} from "@/project-memory/maintenance/classifier";
+import type { Entry, Source } from "@/project-memory/types";
+
+const PROJECT_ID = "project-maintenance";
+const NOW = 1_000_000;
+const OLD = NOW - DEFAULT_MAINTENANCE_STALE_AFTER_MS - 1;
+const RECENT = NOW - 1_000;
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    id: "entry_1",
+    projectId: PROJECT_ID,
+    entityId: "entity_1",
+    type: "note",
+    title: "Stable entry",
+    summary: "Useful project memory note.",
+    status: "active",
+    sensitivity: "internal",
+    createdAt: OLD,
+    updatedAt: RECENT,
+    ...overrides,
+  };
+}
+
+function source(entryId: string): Source {
+  return {
+    id: `source_${entryId}`,
+    projectId: PROJECT_ID,
+    entryId,
+    kind: "manual",
+    pointer: `manual://${entryId}`,
+    createdAt: RECENT,
+  };
+}
+
+describe("project-memory maintenance classifier", () => {
+  it("supersedes exact duplicate entries while keeping the newest copy", () => {
+    const older = entry({ id: "entry_old", updatedAt: OLD });
+    const newest = entry({ id: "entry_new", updatedAt: RECENT });
+
+    const plan = classifyMaintenanceSnapshot({
+      projectId: PROJECT_ID,
+      reason: "dry-run",
+      now: NOW,
+      entries: [older, newest],
+      sources: [source(newest.id)],
+    });
+
+    expect(plan.items).toEqual([
+      {
+        entryId: older.id,
+        kind: "duplicate",
+        action: "supersede",
+        confidence: "high",
+        reason: "Exact duplicate of a newer entry in the same entity/type/title/summary group.",
+        safeByDefault: true,
+      },
+    ]);
+  });
+
+  it("archives low-signal note and todo entries with missing sources", () => {
+    const note = entry({ id: "entry_note", type: "note" });
+    const todo = entry({ id: "entry_todo", type: "todo" });
+
+    const plan = classifyMaintenanceSnapshot({
+      projectId: PROJECT_ID,
+      reason: "scheduled",
+      now: NOW,
+      entries: [note, todo],
+      sources: [],
+    });
+
+    expect(plan.items).toEqual([
+      {
+        entryId: note.id,
+        kind: "missing_source",
+        action: "archive",
+        confidence: "low",
+        reason: "Low-signal note/todo entry has no source pointer.",
+        safeByDefault: true,
+      },
+      {
+        entryId: todo.id,
+        kind: "missing_source",
+        action: "archive",
+        confidence: "low",
+        reason: "Low-signal note/todo entry has no source pointer.",
+        safeByDefault: true,
+      },
+    ]);
+  });
+
+  it("does not delete missing-source decisions or risks", () => {
+    const decision = entry({ id: "entry_decision", type: "decision" });
+    const risk = entry({ id: "entry_risk", type: "risk" });
+
+    const plan = classifyMaintenanceSnapshot({
+      projectId: PROJECT_ID,
+      reason: "manual",
+      now: NOW,
+      entries: [decision, risk],
+      sources: [],
+    });
+
+    expect(plan.items.map((item) => item.action)).toEqual(["needs_review", "needs_review"]);
+    expect(plan.items.every((item) => item.kind === "missing_source" && item.safeByDefault === false)).toBe(true);
+  });
+
+  it("marks old active entries stale but sends old decisions and risks to review", () => {
+    const note = entry({ id: "entry_note", type: "note", updatedAt: OLD });
+    const decision = entry({ id: "entry_decision", type: "decision", updatedAt: OLD });
+    const risk = entry({ id: "entry_risk", type: "risk", updatedAt: OLD });
+
+    const plan = classifyMaintenanceSnapshot({
+      projectId: PROJECT_ID,
+      reason: "scheduled",
+      now: NOW,
+      entries: [note, decision, risk],
+      sources: [source(note.id), source(decision.id), source(risk.id)],
+    });
+
+    expect(plan.items).toEqual([
+      {
+        entryId: note.id,
+        kind: "stale",
+        action: "mark_stale",
+        confidence: "medium",
+        reason: "Active entry is older than the maintenance stale threshold.",
+        safeByDefault: true,
+      },
+      {
+        entryId: decision.id,
+        kind: "stale",
+        action: "needs_review",
+        confidence: "medium",
+        reason: "Old active decision/risk needs human review before staling.",
+        safeByDefault: false,
+      },
+      {
+        entryId: risk.id,
+        kind: "stale",
+        action: "needs_review",
+        confidence: "medium",
+        reason: "Old active decision/risk needs human review before staling.",
+        safeByDefault: false,
+      },
+    ]);
+  });
+
+  it("archives old deprecated and superseded entries", () => {
+    const deprecated = entry({
+      id: "entry_deprecated",
+      status: "deprecated",
+      title: "Deprecated entry",
+      updatedAt: OLD,
+    });
+    const superseded = entry({
+      id: "entry_superseded",
+      status: "superseded",
+      title: "Superseded entry",
+      updatedAt: OLD,
+    });
+
+    const plan = classifyMaintenanceSnapshot({
+      projectId: PROJECT_ID,
+      reason: "scheduled",
+      now: NOW,
+      entries: [deprecated, superseded],
+      sources: [source(deprecated.id), source(superseded.id)],
+    });
+
+    expect(plan.items).toEqual([
+      {
+        entryId: deprecated.id,
+        kind: "deprecated",
+        action: "archive",
+        confidence: "high",
+        reason: "Deprecated entry is older than the maintenance stale threshold.",
+        safeByDefault: true,
+      },
+      {
+        entryId: superseded.id,
+        kind: "superseded",
+        action: "archive",
+        confidence: "high",
+        reason: "Superseded entry is older than the maintenance stale threshold.",
+        safeByDefault: true,
+      },
+    ]);
+  });
+
+  it("plans secret hard deletion without echoing the secret value", () => {
+    const secretValue = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+    const secretEntry = entry({ id: "entry_secret", title: `leaked token=${secretValue}` });
+
+    const plan = classifyMaintenanceSnapshot({
+      projectId: PROJECT_ID,
+      reason: "terminal",
+      now: NOW,
+      entries: [secretEntry],
+      sources: [source(secretEntry.id)],
+    });
+
+    expect(plan.items).toEqual([
+      {
+        entryId: secretEntry.id,
+        kind: "potential_secret",
+        action: "hard_delete_secret",
+        confidence: "high",
+        reason: "Entry title/summary matched secret detector; value intentionally omitted.",
+        safeByDefault: true,
+      },
+    ]);
+    expect(JSON.stringify(plan)).not.toContain(secretValue);
+  });
+
+  it("routes Atlas observations to review only", () => {
+    const atlasObservation = entry({ id: "entry_atlas", title: "Atlas observation: stale-detected — node — reason" });
+
+    const plan = classifyMaintenanceSnapshot({
+      projectId: PROJECT_ID,
+      reason: "dry-run",
+      now: NOW,
+      entries: [atlasObservation],
+      sources: [source(atlasObservation.id)],
+    });
+
+    expect(plan.items).toEqual([
+      {
+        entryId: atlasObservation.id,
+        kind: "stale",
+        action: "needs_review",
+        confidence: "medium",
+        reason: "Atlas observation entries require review instead of automatic mutation.",
+        safeByDefault: false,
+      },
+    ]);
+  });
+
+  it("is a pure snapshot classifier and does not mutate inputs", () => {
+    const stable = entry({ id: "entry_stable" });
+    const snapshot = {
+      projectId: PROJECT_ID,
+      reason: "dry-run" as const,
+      now: NOW,
+      entries: [stable],
+      sources: [source(stable.id)],
+    };
+    const before = JSON.stringify(snapshot);
+
+    const plan = classifyMaintenanceSnapshot(snapshot);
+
+    expect(plan).toEqual({ projectId: PROJECT_ID, reason: "dry-run", items: [] });
+    expect(JSON.stringify(snapshot)).toBe(before);
+  });
+});

--- a/tests/project-memory/maintenance/journal.test.ts
+++ b/tests/project-memory/maintenance/journal.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import {
+  appendMaintenanceJournal,
+  journalPathFor,
+  type MaintenanceJournalEvent,
+  readMaintenanceJournal,
+} from "@/project-memory/maintenance/journal";
+
+const PROJECT_ID = "project-journal";
+const ACTION_SWEEP = "sweep";
+const ACTION_SNAPSHOT = "snapshot";
+const ENTRY_ID = "entry-one";
+const LONG_DETAIL_LENGTH = 300;
+const MAX_STORED_DETAIL_LENGTH = 240;
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "memjournal-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function event(overrides: Partial<MaintenanceJournalEvent> = {}): MaintenanceJournalEvent {
+  return {
+    projectId: PROJECT_ID,
+    action: ACTION_SWEEP,
+    entryIds: [ENTRY_ID],
+    reasons: ["missing_source"],
+    counts: { stale: 1 },
+    at: 1,
+    ...overrides,
+  };
+}
+
+describe("maintenance journal", () => {
+  it("appends events to a project jsonl file and reads them in order", async () => {
+    const first = event({ action: ACTION_SWEEP, at: 1 });
+    const second = event({ action: ACTION_SNAPSHOT, at: 2, counts: { stale: 0, active: 2 } });
+
+    const writtenPath = await appendMaintenanceJournal(first, { dir });
+    await appendMaintenanceJournal(second, { dir });
+
+    expect(writtenPath).toBe(join(dir, `${PROJECT_ID}.jsonl`));
+    expect(writtenPath.startsWith(process.cwd())).toBe(false);
+    expect(existsSync(dirname(writtenPath))).toBe(true);
+    expect(await readMaintenanceJournal(PROJECT_ID, { dir })).toEqual([first, second]);
+  });
+
+  it("truncates long journal details before persisting", async () => {
+    const longDetail = "x".repeat(LONG_DETAIL_LENGTH);
+    const journalEvent = event({ details: longDetail, entrySummaries: [longDetail] });
+
+    const writtenPath = await appendMaintenanceJournal(journalEvent, { dir });
+    const [stored] = await readMaintenanceJournal(PROJECT_ID, { dir });
+    const rawText = readFileSync(writtenPath, "utf8");
+
+    expect(stored?.details).toHaveLength(MAX_STORED_DETAIL_LENGTH);
+    expect(stored?.entrySummaries?.[0]).toHaveLength(MAX_STORED_DETAIL_LENGTH);
+    expect(rawText).not.toContain(longDetail);
+  });
+
+  it("redacts credential-like substrings from journal details and entry summaries", async () => {
+    const rawBearerToken = "Bearer abc.def.ghi";
+    const rawApiKey = "api_key=abc123secret";
+    const rawPassword = "password: hunter2";
+    const rawSecret = "secret token-value";
+    const rawSkToken = "sk-1234567890abcdef1234567890abcdef";
+    const journalEvent = event({
+      details: `failed with ${rawBearerToken} and ${rawApiKey}`,
+      entrySummaries: [`stored ${rawPassword}`, `reported ${rawSecret}`, `provider ${rawSkToken}`],
+    });
+
+    const writtenPath = await appendMaintenanceJournal(journalEvent, { dir });
+    const [stored] = await readMaintenanceJournal(PROJECT_ID, { dir });
+    const rawText = readFileSync(writtenPath, "utf8");
+    const serializedStored = JSON.stringify(stored);
+
+    for (const rawSecretValue of [rawBearerToken, rawApiKey, rawPassword, rawSecret, rawSkToken]) {
+      expect(rawText).not.toContain(rawSecretValue);
+      expect(serializedStored).not.toContain(rawSecretValue);
+    }
+
+    expect(rawText).toContain("[REDACTED]");
+    expect(serializedStored).toContain("[REDACTED]");
+  });
+
+  it("applies read limits after preserving append order", async () => {
+    await appendMaintenanceJournal(event({ action: "first", at: 1 }), { dir });
+    await appendMaintenanceJournal(event({ action: "second", at: 2 }), { dir });
+
+    expect(await readMaintenanceJournal(PROJECT_ID, { dir, limit: 1 })).toEqual([event({ action: "second", at: 2 })]);
+  });
+
+  it("builds default journal paths from config", () => {
+    expect(journalPathFor(PROJECT_ID, new Date("2026-05-16T00:00:00.000Z"))).toContain(`${PROJECT_ID}.jsonl`);
+  });
+});

--- a/tests/project-memory/maintenance/lock.test.ts
+++ b/tests/project-memory/maintenance/lock.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+
+import { acquireMaintenanceLock } from "@/project-memory/maintenance/lock";
+
+const PROJECT_ONE = "project-lock-one";
+const PROJECT_TWO = "project-lock-two";
+
+describe("project-memory maintenance lock", () => {
+  it("returns null for the same project until the lock is released", async () => {
+    const lock = await acquireMaintenanceLock(PROJECT_ONE);
+
+    expect(lock).not.toBeNull();
+    expect(lock?.projectId).toBe(PROJECT_ONE);
+    expect(await acquireMaintenanceLock(PROJECT_ONE)).toBeNull();
+
+    await lock?.release();
+
+    const reacquired = await acquireMaintenanceLock(PROJECT_ONE);
+    expect(reacquired).not.toBeNull();
+    await reacquired?.release();
+  });
+
+  it("allows different projects to hold locks concurrently", async () => {
+    const first = await acquireMaintenanceLock(PROJECT_ONE);
+    const second = await acquireMaintenanceLock(PROJECT_TWO);
+
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+    expect(first?.projectId).toBe(PROJECT_ONE);
+    expect(second?.projectId).toBe(PROJECT_TWO);
+
+    await first?.release();
+    await second?.release();
+  });
+
+  it("allows expired locks to be reacquired without waiting", async () => {
+    const expired = await acquireMaintenanceLock(PROJECT_ONE, { ttlMs: 0 });
+    const reacquired = await acquireMaintenanceLock(PROJECT_ONE);
+
+    expect(expired).not.toBeNull();
+    expect(reacquired).not.toBeNull();
+    expect(reacquired).not.toBe(expired);
+
+    await expired?.release();
+    expect(await acquireMaintenanceLock(PROJECT_ONE)).toBeNull();
+
+    await reacquired?.release();
+  });
+});

--- a/tests/project-memory/maintenance/scheduler.test.ts
+++ b/tests/project-memory/maintenance/scheduler.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { ProjectMemoryIdentityResolution } from "@/project-memory/identity";
+import {
+  createProjectMemoryMaintenanceScheduler,
+  type ScheduleMaintenanceDeps,
+} from "@/project-memory/maintenance/scheduler";
+import type { MaintenanceRunOutcome } from "@/project-memory/maintenance/types";
+
+const PROJECT_ID = "project-scheduler";
+const ORIGIN_IDENTITY = { projectId: PROJECT_ID, kind: "origin" as const, source: "github.com/wuxie233/micode" };
+const RUN_OUTCOME: MaintenanceRunOutcome = {
+  applied: 1,
+  skipped: 2,
+  blocked: 0,
+  warnings: ["review skipped unsafe item"],
+  journalPath: "/tmp/project-scheduler.jsonl",
+};
+
+function resolvedIdentity(): ProjectMemoryIdentityResolution {
+  return { status: "resolved", source: "explicit", identity: ORIGIN_IDENTITY };
+}
+
+function createDeps(overrides: Partial<ScheduleMaintenanceDeps> = {}): ScheduleMaintenanceDeps {
+  return {
+    resolveIdentity: mock(async () => resolvedIdentity()),
+    runWorker: mock(async () => RUN_OUTCOME),
+    appendJournal: mock(async () => "/tmp/project-scheduler.jsonl"),
+    defer: mock((work) => work()),
+    cwd: () => "/repo/worktree",
+    ...overrides,
+  };
+}
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("project-memory maintenance scheduler", () => {
+  it("returns from a terminal schedule before the worker promise resolves", async () => {
+    const deferred: Array<() => void> = [];
+    let resolveWorker: (outcome: MaintenanceRunOutcome) => void = () => undefined;
+    const workerPromise = new Promise<MaintenanceRunOutcome>((resolve) => {
+      resolveWorker = resolve;
+    });
+    const deps = createDeps({
+      defer: mock((work) => deferred.push(work)),
+      runWorker: mock(async () => workerPromise),
+    });
+    const scheduler = createProjectMemoryMaintenanceScheduler(deps);
+
+    const result = await scheduler({ reason: "terminal", triggeredBy: "terminal-hook" });
+
+    expect(result).toEqual({ scheduled: true, reason: "scheduled", projectId: PROJECT_ID, warnings: [] });
+    expect(deferred).toHaveLength(1);
+    expect(deps.runWorker).not.toHaveBeenCalled();
+
+    deferred[0]?.();
+    await flushPromises();
+
+    expect(deps.runWorker).toHaveBeenCalledWith({
+      projectId: PROJECT_ID,
+      reason: "terminal",
+      dryRun: false,
+      triggeredBy: "terminal-hook",
+      sourcePointers: undefined,
+    });
+
+    resolveWorker(RUN_OUTCOME);
+    await flushPromises();
+  });
+
+  it("captures detached worker rejection in the maintenance journal without rejecting schedule", async () => {
+    const deferred: Array<() => void> = [];
+    const deps = createDeps({
+      defer: mock((work) => deferred.push(work)),
+      runWorker: mock(async () => {
+        throw new Error("worker exploded");
+      }),
+    });
+    const scheduler = createProjectMemoryMaintenanceScheduler(deps);
+
+    await expect(scheduler({ reason: "terminal", triggeredBy: "terminal-hook" })).resolves.toMatchObject({
+      scheduled: true,
+      reason: "scheduled",
+    });
+
+    deferred[0]?.();
+    await flushPromises();
+
+    expect(deps.appendJournal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: PROJECT_ID,
+        action: "scheduler_error",
+        details: "worker exploded",
+        counts: { warnings: 1 },
+      }),
+    );
+  });
+
+  it("blocks ambiguous and degraded identities before queueing maintenance", async () => {
+    const ambiguousDeps = createDeps({
+      resolveIdentity: mock(async () => ({
+        status: "ambiguous" as const,
+        source: "registry" as const,
+        reason: "project identity is ambiguous",
+        candidates: [{ projectId: "one" }, { projectId: "two" }],
+      })),
+    });
+    const ambiguous = createProjectMemoryMaintenanceScheduler(ambiguousDeps);
+
+    await expect(ambiguous({ reason: "terminal" })).resolves.toMatchObject({
+      scheduled: false,
+      reason: "blocked: project identity is ambiguous",
+    });
+    expect(ambiguousDeps.runWorker).not.toHaveBeenCalled();
+
+    const degradedDeps = createDeps({
+      resolveIdentity: mock(async () => ({
+        status: "degraded" as const,
+        source: "degraded" as const,
+        reason: "project identity resolved from path only; origin not resolved",
+        identity: { projectId: "path-only", kind: "path" as const, source: "/repo/worktree" },
+      })),
+    });
+    const degraded = createProjectMemoryMaintenanceScheduler(degradedDeps);
+
+    await expect(degraded({ reason: "scheduled" })).resolves.toMatchObject({
+      scheduled: false,
+      reason: "blocked: project identity resolved from path only; origin not resolved",
+    });
+    expect(degradedDeps.runWorker).not.toHaveBeenCalled();
+  });
+
+  it("executes dry-run maintenance immediately and returns the worker outcome", async () => {
+    const deps = createDeps();
+    const scheduler = createProjectMemoryMaintenanceScheduler(deps);
+
+    const result = await scheduler({ reason: "manual", dryRun: true, triggeredBy: "manual-tool" });
+
+    expect(result).toEqual({
+      scheduled: false,
+      reason: "dry-run-executed",
+      projectId: PROJECT_ID,
+      warnings: RUN_OUTCOME.warnings,
+      workerOutcome: RUN_OUTCOME,
+    });
+    expect(deps.defer).not.toHaveBeenCalled();
+    expect(deps.runWorker).toHaveBeenCalledWith({
+      projectId: PROJECT_ID,
+      reason: "manual",
+      dryRun: true,
+      triggeredBy: "manual-tool",
+      sourcePointers: undefined,
+    });
+  });
+});

--- a/tests/project-memory/maintenance/types.test.ts
+++ b/tests/project-memory/maintenance/types.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "bun:test";
+import * as v from "valibot";
+
+import {
+  MaintenanceActionKindSchema,
+  MaintenanceActionKindValues,
+  MaintenanceCandidateKindSchema,
+  MaintenanceCandidateKindValues,
+  MaintenanceJournalEventSchema,
+  MaintenancePlanItemSchema,
+  MaintenancePlanSchema,
+  MaintenanceReasonSchema,
+  MaintenanceReasonValues,
+  MaintenanceRunInputSchema,
+  MaintenanceRunOutcomeSchema,
+} from "@/project-memory/maintenance/types";
+
+describe("project-memory maintenance types", () => {
+  it("declares maintenance reason vocabulary and schema", () => {
+    expect(MaintenanceReasonValues).toEqual(["manual", "terminal", "scheduled", "dry-run"]);
+
+    for (const reason of MaintenanceReasonValues) {
+      expect(v.safeParse(MaintenanceReasonSchema, reason).success).toBe(true);
+    }
+  });
+
+  it("declares candidate kind vocabulary and schema", () => {
+    expect(MaintenanceCandidateKindValues).toEqual([
+      "duplicate",
+      "missing_source",
+      "stale",
+      "superseded",
+      "deprecated",
+      "low_signal",
+      "potential_secret",
+      "orphan",
+    ]);
+
+    for (const kind of MaintenanceCandidateKindValues) {
+      expect(v.safeParse(MaintenanceCandidateKindSchema, kind).success).toBe(true);
+    }
+  });
+
+  it("declares action kind vocabulary and keeps hard_delete_secret distinct", () => {
+    expect(MaintenanceActionKindValues).toEqual([
+      "archive",
+      "tombstone",
+      "supersede",
+      "mark_stale",
+      "deduplicate",
+      "refine_summary",
+      "hard_delete_secret",
+      "needs_review",
+      "skip",
+    ]);
+
+    for (const action of MaintenanceActionKindValues) {
+      expect(v.safeParse(MaintenanceActionKindSchema, action).success).toBe(true);
+    }
+
+    expect(MaintenanceActionKindValues).toContain("hard_delete_secret");
+    expect(MaintenanceActionKindValues).not.toContain("hard_delete");
+  });
+
+  it("accepts maintenance plan items and plans", () => {
+    const item = {
+      entryId: "entry_1",
+      kind: "potential_secret" as const,
+      action: "hard_delete_secret" as const,
+      confidence: "high" as const,
+      reason: "Looks like a secret-bearing entry.",
+      safeByDefault: false,
+    };
+
+    expect(v.safeParse(MaintenancePlanItemSchema, item).success).toBe(true);
+    expect(
+      v.safeParse(MaintenancePlanSchema, {
+        projectId: "project_1",
+        reason: "manual" as const,
+        items: [item],
+        warnings: ["secret deletion requires review"],
+      }).success,
+    ).toBe(true);
+  });
+
+  it("accepts run inputs, outcomes, and journal events", () => {
+    expect(
+      v.safeParse(MaintenanceRunInputSchema, {
+        projectId: "project_1",
+        reason: "dry-run" as const,
+        dryRun: true,
+        triggeredBy: "test",
+        sourcePointers: ["manual://operator"],
+      }).success,
+    ).toBe(true);
+
+    expect(
+      v.safeParse(MaintenanceRunOutcomeSchema, {
+        applied: 0,
+        skipped: 1,
+        blocked: 1,
+        warnings: ["dry run"],
+        journalPath: "/tmp/project_1.jsonl",
+      }).success,
+    ).toBe(true);
+
+    expect(
+      v.safeParse(MaintenanceJournalEventSchema, {
+        projectId: "project_1",
+        action: "hard_delete_secret" as const,
+        at: 1,
+        entryIds: ["entry_1"],
+        reasons: ["potential_secret"],
+        counts: { blocked: 1 },
+      }).success,
+    ).toBe(true);
+  });
+});

--- a/tests/project-memory/maintenance/worker.test.ts
+++ b/tests/project-memory/maintenance/worker.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readMaintenanceJournal } from "@/project-memory/maintenance/journal";
+import { acquireMaintenanceLock } from "@/project-memory/maintenance/lock";
+import { runProjectMemoryMaintenance } from "@/project-memory/maintenance/worker";
+import { createProjectMemoryStore, type ProjectMemoryStore } from "@/project-memory/store";
+import type { Entity, Entry, Source } from "@/project-memory/types";
+import type { ProjectIdentity } from "@/utils/project-id";
+
+const PROJECT_ID = "project-worker";
+const ENTITY_ID = "entity-worker";
+const ENTRY_ID = "entry-worker";
+const NOW = 1_000_000;
+const OLD = 1;
+
+const IDENTITY: ProjectIdentity = {
+  projectId: PROJECT_ID,
+  kind: "origin",
+  source: "github.com/wuxie233/micode",
+};
+
+let root: string;
+let store: ProjectMemoryStore;
+
+beforeEach(async () => {
+  root = mkdtempSync(join(tmpdir(), "memworker-"));
+  store = createProjectMemoryStore({ dbDir: join(root, "db") });
+  await store.initialize();
+  await store.upsertEntity(entity());
+});
+
+afterEach(async () => {
+  await store.close().catch(() => undefined);
+  rmSync(root, { recursive: true, force: true });
+});
+
+function journalDir(): string {
+  return join(root, "journal");
+}
+
+function entity(overrides: Partial<Entity> = {}): Entity {
+  return {
+    projectId: PROJECT_ID,
+    id: ENTITY_ID,
+    kind: "module",
+    name: "worker",
+    summary: "Maintenance worker",
+    createdAt: OLD,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    projectId: PROJECT_ID,
+    id: ENTRY_ID,
+    entityId: ENTITY_ID,
+    type: "note",
+    title: "Worker note",
+    summary: "Useful project memory note.",
+    status: "active",
+    sensitivity: "internal",
+    createdAt: OLD,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+function source(entryId: string): Source {
+  return {
+    projectId: PROJECT_ID,
+    id: `source_${entryId}`,
+    entryId,
+    kind: "manual",
+    pointer: `manual://${entryId}`,
+    createdAt: NOW,
+  };
+}
+
+function runInput(
+  overrides: Partial<Parameters<typeof runProjectMemoryMaintenance>[0]> = {},
+): Parameters<typeof runProjectMemoryMaintenance>[0] {
+  return {
+    projectId: PROJECT_ID,
+    reason: "scheduled",
+    dryRun: false,
+    triggeredBy: "test",
+    store,
+    identity: IDENTITY,
+    journalDir: journalDir(),
+    now: NOW,
+    ...overrides,
+  };
+}
+
+describe("project-memory maintenance worker", () => {
+  it("returns a dry-run plan and journal without mutating entries", async () => {
+    await store.upsertEntry(entry({ id: "entry_note", type: "note" }));
+
+    const outcome = await runProjectMemoryMaintenance(runInput({ dryRun: true, reason: "dry-run" }));
+
+    expect(outcome.applied).toBe(0);
+    expect(outcome.skipped).toBe(1);
+    expect(outcome.blocked).toBe(0);
+    expect(outcome.plan.items.map((item) => item.entryId)).toEqual(["entry_note"]);
+    expect((await store.loadEntry(PROJECT_ID, "entry_note"))?.status).toBe("active");
+    expect((await readMaintenanceJournal(PROJECT_ID, { dir: journalDir() }))[0]).toMatchObject({
+      action: "skip",
+      counts: { planned: 1, applied: 0, skipped: 1, blocked: 0 },
+    });
+  });
+
+  it("supersedes the older duplicate entry while keeping the newest active", async () => {
+    await store.upsertEntry(entry({ id: "entry_old", updatedAt: OLD }));
+    await store.upsertEntry(entry({ id: "entry_new", updatedAt: NOW }));
+    await store.upsertSource(source("entry_new"));
+
+    const outcome = await runProjectMemoryMaintenance(runInput());
+
+    expect(outcome.applied).toBe(1);
+    expect(outcome.skipped).toBe(0);
+    expect((await store.loadEntry(PROJECT_ID, "entry_old"))?.status).toBe("superseded");
+    expect((await store.loadEntry(PROJECT_ID, "entry_new"))?.status).toBe("active");
+  });
+
+  it("keeps missing-source decisions for review instead of hard deleting them", async () => {
+    await store.upsertEntry(entry({ id: "entry_decision", type: "decision" }));
+
+    const outcome = await runProjectMemoryMaintenance(runInput());
+
+    expect(outcome.applied).toBe(0);
+    expect(outcome.blocked).toBe(1);
+    expect((await store.loadEntry(PROJECT_ID, "entry_decision"))?.status).toBe("active");
+    expect(outcome.plan.items[0]).toMatchObject({ action: "needs_review", safeByDefault: false });
+  });
+
+  it("hard deletes potential secrets without leaking the secret into the journal", async () => {
+    const secretValue = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+    await store.upsertEntry(entry({ id: "entry_secret", title: `leaked token=${secretValue}` }));
+    await store.upsertSource(source("entry_secret"));
+
+    const outcome = await runProjectMemoryMaintenance(runInput());
+    const journal = await readMaintenanceJournal(PROJECT_ID, { dir: journalDir() });
+
+    expect(outcome.applied).toBe(1);
+    expect(await store.loadEntry(PROJECT_ID, "entry_secret")).toBeNull();
+    expect(JSON.stringify(outcome)).not.toContain(secretValue);
+    expect(JSON.stringify(journal)).not.toContain(secretValue);
+    expect(journal[0]).toMatchObject({ action: "hard_delete_secret", entryIds: ["entry_secret"] });
+  });
+
+  it("returns a skipped warning when the project maintenance lock is already held", async () => {
+    const lock = await acquireMaintenanceLock(PROJECT_ID);
+    try {
+      const outcome = await runProjectMemoryMaintenance(runInput());
+
+      expect(outcome.applied).toBe(0);
+      expect(outcome.skipped).toBe(1);
+      expect(outcome.warnings).toEqual(["project memory maintenance skipped: lock already held"]);
+    } finally {
+      await lock?.release();
+    }
+  });
+
+  it("writes a failure journal warning and returns instead of throwing", async () => {
+    const failingStore: ProjectMemoryStore = {
+      ...store,
+      listEntries: async () => {
+        throw new Error("snapshot failed");
+      },
+    };
+
+    const outcome = await runProjectMemoryMaintenance(runInput({ store: failingStore }));
+    const journal = await readMaintenanceJournal(PROJECT_ID, { dir: journalDir() });
+
+    expect(outcome.applied).toBe(0);
+    expect(outcome.skipped).toBe(0);
+    expect(outcome.blocked).toBe(1);
+    expect(outcome.warnings).toEqual(["project memory maintenance failed: snapshot failed"]);
+    expect(journal[0]).toMatchObject({
+      action: "needs_review",
+      details: "project memory maintenance failed: snapshot failed",
+    });
+  });
+});

--- a/tests/project-memory/registry.test.ts
+++ b/tests/project-memory/registry.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { createProjectRegistry } from "@/project-memory/registry";
+
+const UPDATED_AT = 1_234;
+const EXPECTED_TWO = 2;
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "pm-registry-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function registryPath(): string {
+  return join(dir, "registry.json");
+}
+
+describe("ProjectRegistry", () => {
+  it("returns an empty list when the registry file is missing", async () => {
+    const registry = createProjectRegistry({ filePath: registryPath() });
+
+    expect(await registry.load()).toEqual([]);
+  });
+
+  it("upserts records and finds them by exact normalized alias", async () => {
+    const registry = createProjectRegistry({ filePath: registryPath() });
+
+    await registry.upsert({
+      projectId: "project-one",
+      aliases: ["  MiCode  ", "Plugin"],
+      worktrees: [],
+      updatedAt: UPDATED_AT,
+    });
+
+    expect((await registry.findByAlias("micode")).map((record) => record.projectId)).toEqual(["project-one"]);
+    expect(await registry.findByAlias("mico")).toEqual([]);
+    expect((await registry.load())[0]?.aliases).toEqual(["micode", "plugin"]);
+  });
+
+  it("treats SSH and HTTPS origins for the same repository as identical", async () => {
+    const registry = createProjectRegistry({ filePath: registryPath() });
+
+    await registry.upsert({
+      projectId: "project-one",
+      origin: "git@github.com:Wuxie233/micode.git",
+      aliases: [],
+      worktrees: [],
+      updatedAt: UPDATED_AT,
+    });
+
+    expect(
+      (await registry.findByOrigin("https://github.com/wuxie233/micode.git")).map((record) => record.projectId),
+    ).toEqual(["project-one"]);
+    expect((await registry.load())[0]?.origin).toBe("github.com/wuxie233/micode");
+  });
+
+  it("normalizes worktree paths to absolute paths before matching", async () => {
+    const registry = createProjectRegistry({ filePath: registryPath() });
+    const worktree = join(dir, "../project-worktree");
+
+    await registry.upsert({
+      projectId: "project-one",
+      aliases: [],
+      worktrees: [worktree],
+      updatedAt: UPDATED_AT,
+    });
+
+    expect((await registry.findByWorktree(worktree)).map((record) => record.projectId)).toEqual(["project-one"]);
+    expect((await registry.load())[0]?.worktrees).toEqual([resolve(worktree)]);
+  });
+
+  it("returns all records that share the same exact alias", async () => {
+    const registry = createProjectRegistry({ filePath: registryPath() });
+
+    await registry.upsert({ projectId: "project-one", aliases: ["micode"], worktrees: [], updatedAt: UPDATED_AT });
+    await registry.upsert({ projectId: "project-two", aliases: ["micode"], worktrees: [], updatedAt: UPDATED_AT });
+
+    const matches = await registry.findByAlias("micode");
+
+    expect(matches).toHaveLength(EXPECTED_TWO);
+    expect(matches.map((record) => record.projectId)).toEqual(["project-one", "project-two"]);
+  });
+});

--- a/tests/project-memory/store.test.ts
+++ b/tests/project-memory/store.test.ts
@@ -250,6 +250,84 @@ describe("ProjectMemoryStore", () => {
     expect(onlyPublic.map((hit) => hit.entry.id)).toEqual(["entry-four"]);
   });
 
+  it("returns zero counts for every known status before entries exist", async () => {
+    const store = createStore();
+    await store.initialize();
+
+    expect(await store.countEntriesByStatus(PROJECT_ONE)).toEqual(statusCounts());
+  });
+
+  it("keeps archived entries searchable after a soft status update", async () => {
+    const store = createStore();
+    await store.initialize();
+
+    await store.upsertEntity(entity());
+    await store.upsertEntry(entry({ title: "Alpha title", summary: "bravo archived context" }));
+
+    await store.updateEntryStatus(PROJECT_ONE, ENTRY_ID, "archived", 123);
+
+    expect(await store.loadEntry(PROJECT_ONE, ENTRY_ID)).toEqual(
+      entry({ title: "Alpha title", summary: "bravo archived context", status: "archived", updatedAt: 123 }),
+    );
+    expect(
+      (await store.searchEntries(PROJECT_ONE, "alpha", { status: "archived", limit: 5 })).map((hit) => hit.entry.id),
+    ).toEqual([ENTRY_ID]);
+    expect(await store.searchEntries(PROJECT_ONE, "alpha", { status: "active", limit: 5 })).toEqual([]);
+  });
+
+  it("lists entries by project with status filtering and explicit limits", async () => {
+    const store = createStore();
+    await store.initialize();
+
+    await store.upsertEntity(entity());
+    await store.upsertEntry(entry({ id: ENTRY_ID, status: "active", updatedAt: 20 }));
+    await store.upsertEntry(entry({ id: OTHER_ENTRY_ID, status: "archived", updatedAt: 30 }));
+    await store.upsertEntry(entry({ id: THIRD_ENTRY_ID, status: "archived", updatedAt: 30 }));
+    await store.upsertEntry(
+      entry({ projectId: PROJECT_TWO, id: "project-two-entry", status: "archived", updatedAt: 40 }),
+    );
+
+    expect((await store.listEntries(PROJECT_ONE)).map((row) => row.id)).toEqual([
+      THIRD_ENTRY_ID,
+      OTHER_ENTRY_ID,
+      ENTRY_ID,
+    ]);
+    expect((await store.listEntries(PROJECT_ONE, { status: "archived", limit: 1 })).map((row) => row.id)).toEqual([
+      THIRD_ENTRY_ID,
+    ]);
+  });
+
+  it("lists entities and sources for a project with explicit limits", async () => {
+    const store = createStore();
+    await store.initialize();
+
+    await store.upsertEntity(entity({ id: ENTITY_ID, updatedAt: 20 }));
+    await store.upsertEntity(entity({ id: OTHER_ENTITY_ID, name: "billing", updatedAt: 30 }));
+    await store.upsertEntity(entity({ projectId: PROJECT_TWO, id: "project-two-entity", updatedAt: 40 }));
+    await store.upsertEntry(entry());
+    await store.upsertSource(source({ id: SOURCE_ID, createdAt: 20 }));
+    await store.upsertSource(source({ id: OTHER_SOURCE_ID, createdAt: 30 }));
+    await store.upsertSource(source({ projectId: PROJECT_TWO, id: "project-two-source", createdAt: 40 }));
+
+    expect((await store.listEntities(PROJECT_ONE, { limit: 1 })).map((row) => row.id)).toEqual([OTHER_ENTITY_ID]);
+    expect((await store.listSources(PROJECT_ONE, { limit: 1 })).map((row) => row.id)).toEqual([OTHER_SOURCE_ID]);
+  });
+
+  it("updates entry summaries through the searchable FTS snapshot", async () => {
+    const store = createStore();
+    await store.initialize();
+
+    await store.upsertEntity(entity());
+    await store.upsertEntry(entry({ summary: "alpha original" }));
+
+    await store.updateEntrySummary(PROJECT_ONE, ENTRY_ID, "gamma updated", 456);
+
+    expect(await store.searchEntries(PROJECT_ONE, "alpha", { limit: 5 })).toEqual([]);
+    expect((await store.searchEntries(PROJECT_ONE, "gamma", { limit: 5 })).map((hit) => hit.entry)).toEqual([
+      entry({ summary: "gamma updated", updatedAt: 456 }),
+    ]);
+  });
+
   it("counts missing sources and forgets matching source rows", async () => {
     const store = createStore();
     await store.initialize();

--- a/tests/project-memory/types.test.ts
+++ b/tests/project-memory/types.test.ts
@@ -8,6 +8,7 @@ import {
   RelationKindValues,
   SourceKindValues,
   SourceSchema,
+  StatusValues,
 } from "@/project-memory/types";
 
 describe("project-memory types", () => {
@@ -61,6 +62,26 @@ describe("project-memory types", () => {
       title: "x",
       summary: "y",
       status: "active",
+      sensitivity: "internal",
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("declares cleanup statuses", () => {
+    expect(StatusValues).toEqual(expect.arrayContaining(["archived", "tombstoned", "stale"]));
+  });
+
+  it.each(["archived", "tombstoned", "stale"] as const)("accepts %s entries", (status) => {
+    const result = v.safeParse(EntrySchema, {
+      id: `e_${status}`,
+      projectId: "abc",
+      entityId: "ent_1",
+      type: "decision",
+      title: "x",
+      summary: "y",
+      status,
       sensitivity: "internal",
       createdAt: 1,
       updatedAt: 1,

--- a/tests/tools/project-memory/forget.test.ts
+++ b/tests/tools/project-memory/forget.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { PluginInput } from "@opencode-ai/plugin";
@@ -7,11 +7,15 @@ import type { ToolContext, ToolResult } from "@opencode-ai/plugin/tool";
 import { $ } from "bun";
 import type { Entity, Entry, Source } from "@/project-memory";
 import { createProjectMemoryStore, type ProjectMemoryStore } from "@/project-memory";
+import { createProjectRegistry } from "@/project-memory/registry";
 import { createProjectMemoryForgetTool } from "@/tools/project-memory/forget";
 import { resetProjectMemoryRuntimeForTest, setProjectMemoryStoreForTest } from "@/tools/project-memory/runtime";
-import { type ProjectIdentity, resolveProjectId } from "@/utils/project-id";
+import { config } from "@/utils/config";
+import { type ProjectIdentity, projectIdForSource, resolveProjectId } from "@/utils/project-id";
 
 const REMOTE = "https://github.com/Wuxie233/micode.git";
+const OTHER_REMOTE = "https://github.com/Wuxie233/other-project.git";
+const OTHER_REMOTE_SOURCE = "github.com/wuxie233/other-project";
 const TOOL_CONTEXT = {} as unknown as ToolContext;
 const ENTITY_ID = "entity-one";
 const OTHER_ENTITY_ID = "entity-two";
@@ -24,6 +28,7 @@ const DESIGN_POINTER = "thoughts/shared/designs/example.md";
 const CREATED_AT = 1;
 const UPDATED_AT = 2;
 const PROJECT_PREFIX_LENGTH = 8;
+const ALIAS = "micode";
 
 type ExecuteSignature = (raw: unknown, ctx: ToolContext) => Promise<ToolResult>;
 
@@ -31,10 +36,13 @@ let workdir: string;
 let dir: string;
 let store: ProjectMemoryStore;
 let identity: ProjectIdentity;
+let originalRegistryFile: string;
 
 beforeEach(async () => {
   workdir = mkdtempSync(join(tmpdir(), "pm-forget-tool-work-"));
   dir = mkdtempSync(join(tmpdir(), "pm-forget-tool-store-"));
+  originalRegistryFile = config.projectMemory.registryFile;
+  (config.projectMemory as { registryFile: string }).registryFile = join(dir, "registry.json");
   await $`git init -q`.cwd(workdir);
   await $`git remote add origin ${REMOTE}`.cwd(workdir);
   identity = await resolveProjectId(workdir);
@@ -45,6 +53,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await resetProjectMemoryRuntimeForTest();
+  (config.projectMemory as { registryFile: string }).registryFile = originalRegistryFile;
   rmSync(workdir, { recursive: true, force: true });
   rmSync(dir, { recursive: true, force: true });
 });
@@ -55,6 +64,10 @@ function pluginInput(): PluginInput {
 
 function projectPrefix(): string {
   return identity.projectId.slice(0, PROJECT_PREFIX_LENGTH);
+}
+
+function prefix(projectId: string): string {
+  return projectId.slice(0, PROJECT_PREFIX_LENGTH);
 }
 
 function stringify(outcome: ToolResult): string {
@@ -108,6 +121,14 @@ function source(overrides: Partial<Source> = {}): Source {
     createdAt: CREATED_AT,
     ...overrides,
   };
+}
+
+function entityFor(projectId: string, overrides: Partial<Entity> = {}): Entity {
+  return entity({ projectId, ...overrides });
+}
+
+function entryFor(projectId: string, overrides: Partial<Entry> = {}): Entry {
+  return entry({ projectId, ...overrides });
 }
 
 async function seedEntry(): Promise<void> {
@@ -183,5 +204,77 @@ describe("project_memory_forget tool", () => {
     const output = await executeForget({ target: "project" });
 
     expect(output.startsWith("## Error\n\n")).toBe(true);
+  });
+
+  it("forgets by explicit origin from a non-project directory", async () => {
+    const nonProjectDir = join(dir, "plain");
+    mkdirSync(nonProjectDir);
+    const targetProjectId = projectIdForSource(OTHER_REMOTE_SOURCE);
+    await store.upsertEntity(entityFor(identity.projectId));
+    await store.upsertEntry(entryFor(identity.projectId));
+    await store.upsertEntity(entityFor(targetProjectId, { id: OTHER_ENTITY_ID, name: "billing" }));
+    await store.upsertEntry(
+      entryFor(targetProjectId, { id: OTHER_ENTRY_ID, entityId: OTHER_ENTITY_ID, title: "Other", summary: "other" }),
+    );
+
+    const tools = createProjectMemoryForgetTool({ directory: nonProjectDir } as unknown as PluginInput);
+    const exec = tools.project_memory_forget.execute.bind(tools.project_memory_forget) as unknown as ExecuteSignature;
+    const output = stringify(
+      await exec({ target: "entry", entry_id: OTHER_ENTRY_ID, project_origin: OTHER_REMOTE }, TOOL_CONTEXT),
+    );
+
+    expect(output).toContain(`Removed 1 entry ${OTHER_ENTRY_ID} for project ${prefix(targetProjectId)}`);
+    expect(await store.loadEntry(targetProjectId, OTHER_ENTRY_ID)).toBeNull();
+    expect(await store.loadEntry(identity.projectId, ENTRY_ID)).not.toBeNull();
+  });
+
+  it("refuses degraded write identity and leaves the store unchanged", async () => {
+    const plainDir = join(dir, "degraded");
+    mkdirSync(plainDir);
+    await seedEntry();
+
+    const tools = createProjectMemoryForgetTool({ directory: plainDir } as unknown as PluginInput);
+    const exec = tools.project_memory_forget.execute.bind(tools.project_memory_forget) as unknown as ExecuteSignature;
+    const output = stringify(await exec({ target: "entry", entry_id: ENTRY_ID }, TOOL_CONTEXT));
+
+    expect(output).toContain("## Error");
+    expect(output.toLowerCase()).toContain("degraded identity");
+    expect(await store.loadEntry(identity.projectId, ENTRY_ID)).not.toBeNull();
+  });
+
+  it("refuses ambiguous write identity and leaves the store unchanged", async () => {
+    const firstProjectId = identity.projectId;
+    const secondProjectId = projectIdForSource(OTHER_REMOTE_SOURCE);
+    const registry = createProjectRegistry({ filePath: config.projectMemory.registryFile });
+    await registry.upsert({
+      projectId: firstProjectId,
+      origin: REMOTE,
+      aliases: [ALIAS],
+      worktrees: [],
+      updatedAt: UPDATED_AT,
+    });
+    await registry.upsert({
+      projectId: secondProjectId,
+      origin: OTHER_REMOTE,
+      aliases: [ALIAS],
+      worktrees: [],
+      updatedAt: UPDATED_AT,
+    });
+    await store.upsertEntity(entityFor(firstProjectId));
+    await store.upsertEntry(entryFor(firstProjectId));
+    await store.upsertEntity(entityFor(secondProjectId, { id: OTHER_ENTITY_ID, name: "billing" }));
+    await store.upsertEntry(
+      entryFor(secondProjectId, { id: OTHER_ENTRY_ID, entityId: OTHER_ENTITY_ID, title: "Other", summary: "other" }),
+    );
+
+    const output = await executeForget({
+      target: "project",
+      project_alias: ALIAS,
+    });
+
+    expect(output).toContain("## Error");
+    expect(output.toLowerCase()).toContain("ambiguous");
+    expect(await store.countEntries(firstProjectId)).toBe(1);
+    expect(await store.countEntries(secondProjectId)).toBe(1);
   });
 });

--- a/tests/tools/project-memory/index.test.ts
+++ b/tests/tools/project-memory/index.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { PluginInput } from "@opencode-ai/plugin";
+import { OpenCodeConfigPlugin } from "@/index";
+import { stopSharedServer } from "@/octto/session/server";
+import { createProjectMemoryMaintainTool } from "@/tools";
+import { createProjectMemoryMaintainTool as createProjectMemoryMaintainToolFromProjectMemory } from "@/tools/project-memory";
+import { config } from "@/utils/config";
+
+const SESSION_ID = "project-memory-index-test-session";
+const PREFIX = "pm-index-tool-map-";
+
+const originalPersistedSessionsDir = config.octto.persistedSessionsDir;
+
+let tempRoot: string | undefined;
+
+function restorePersistedSessionsDir(): void {
+  Object.defineProperty(config.octto, "persistedSessionsDir", {
+    configurable: true,
+    value: originalPersistedSessionsDir,
+    writable: true,
+  });
+}
+
+function setPersistedSessionsDir(baseDir: string): void {
+  Object.defineProperty(config.octto, "persistedSessionsDir", {
+    configurable: true,
+    value: join(baseDir, "sessions"),
+    writable: true,
+  });
+}
+
+function createCtx(directory: string): PluginInput {
+  return {
+    directory,
+    client: {
+      session: {
+        create: async () => ({ data: { id: SESSION_ID } }),
+        prompt: async () => ({ data: { parts: [] } }),
+        delete: async () => ({ data: { id: SESSION_ID } }),
+        messages: async () => ({ data: [] }),
+        abort: async () => ({ data: { id: SESSION_ID } }),
+        summarize: async () => ({ data: { id: SESSION_ID } }),
+      },
+      tui: {
+        showToast: async () => undefined,
+      },
+    },
+  } as unknown as PluginInput;
+}
+
+afterEach(async () => {
+  await stopSharedServer();
+  restorePersistedSessionsDir();
+  if (!tempRoot) return;
+  rmSync(tempRoot, { recursive: true, force: true });
+  tempRoot = undefined;
+});
+
+describe("project memory tool barrels", () => {
+  it("re-exports createProjectMemoryMaintainTool from project-memory and top-level barrels", () => {
+    expect(typeof createProjectMemoryMaintainToolFromProjectMemory).toBe("function");
+    expect(typeof createProjectMemoryMaintainTool).toBe("function");
+    expect(createProjectMemoryMaintainTool).toBe(createProjectMemoryMaintainToolFromProjectMemory);
+  });
+
+  it("registers project_memory_maintain in the plugin tool map", async () => {
+    tempRoot = mkdtempSync(join(tmpdir(), PREFIX));
+    setPersistedSessionsDir(tempRoot);
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      const plugin = await OpenCodeConfigPlugin(createCtx(tempRoot));
+
+      expect(Object.keys(plugin.tool ?? {})).toContain("project_memory_maintain");
+    } finally {
+      logSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
+});

--- a/tests/tools/project-memory/lookup.test.ts
+++ b/tests/tools/project-memory/lookup.test.ts
@@ -1,22 +1,33 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { PluginInput, ToolDefinition } from "@opencode-ai/plugin";
 import type { ToolContext, ToolResult } from "@opencode-ai/plugin/tool";
 
+import { createProjectRegistry } from "@/project-memory/registry";
 import { createProjectMemoryStore, type ProjectMemoryStore } from "@/project-memory/store";
 import { type Entity, type Entry, type Source, type Status, StatusValues } from "@/project-memory/types";
 import { createProjectMemoryLookupTool } from "@/tools/project-memory/lookup";
 import { resetProjectMemoryRuntimeForTest, setProjectMemoryStoreForTest } from "@/tools/project-memory/runtime";
-import { resolveProjectId } from "@/utils/project-id";
+import { config } from "@/utils/config";
+import { projectIdForSource, resolveProjectId } from "@/utils/project-id";
 
 const QUERY = "permission";
 const ACTIVE_TITLE = "Cache permission TTL";
 const TENTATIVE_TITLE = "Tentative permission cache";
+const ARCHIVED_TITLE = "Archived permission cache";
+const TOMBSTONED_TITLE = "Tombstoned permission cache";
+const DEPRECATED_TITLE = "Deprecated permission cache";
+const SUPERSEDED_TITLE = "Superseded permission cache";
+const TARGET_TITLE = "Target origin permission cache";
+const ALIAS_TARGET_TITLE = "Alias origin permission cache";
 const ENTITY_ID = "entity-auth";
 const ACTIVE_ENTRY_ID = "entry-active";
 const TENTATIVE_ENTRY_ID = "entry-tentative";
+const ORIGIN_URL = "https://github.com/Wuxie233/other-project.git";
+const ORIGIN_SOURCE = "github.com/wuxie233/other-project";
+const PROJECT_ALIAS = "other-project";
 const SOURCE_ID = "source-active";
 const POINTER = "manual://permission-cache";
 const CREATED_AT = 1;
@@ -98,6 +109,16 @@ async function seedMemory(store: ProjectMemoryStore, projectId: string): Promise
   await store.upsertSource(source(projectId));
 }
 
+async function seedStatusEntry(
+  store: ProjectMemoryStore,
+  projectId: string,
+  status: Status,
+  title: string,
+  id = `entry-${status}`,
+): Promise<void> {
+  await store.upsertEntry(entry(projectId, { id, title, status }));
+}
+
 function createFailingStore(): ProjectMemoryStore {
   return {
     initialize: async () => {},
@@ -127,9 +148,15 @@ function createFailingStore(): ProjectMemoryStore {
 
 describe("project_memory_lookup", () => {
   let directory: string;
+  let originalRegistryFile: string;
+
+  beforeEach(() => {
+    originalRegistryFile = config.projectMemory.registryFile;
+  });
 
   afterEach(async () => {
     await resetProjectMemoryRuntimeForTest();
+    (config.projectMemory as { registryFile: string }).registryFile = originalRegistryFile;
     rmSync(directory, { recursive: true, force: true });
   });
 
@@ -154,6 +181,109 @@ describe("project_memory_lookup", () => {
       expect(output).toContain(POINTER);
       expect(output).toContain("Query: `permission`");
       expect(output).not.toContain(TENTATIVE_TITLE);
+    },
+    PROJECT_MEMORY_TOOL_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "excludes historical statuses by default and returns archived entries when explicitly requested",
+    async () => {
+      directory = mkdtempSync(join(tmpdir(), "pm-lookup-tool-history-"));
+      const identity = await resolveProjectId(directory);
+      const store = createProjectMemoryStore({ dbDir: join(directory, "memory") });
+      await seedMemory(store, identity.projectId);
+      await seedStatusEntry(store, identity.projectId, "archived", ARCHIVED_TITLE);
+      await seedStatusEntry(store, identity.projectId, "tombstoned", TOMBSTONED_TITLE);
+      await seedStatusEntry(store, identity.projectId, "deprecated", DEPRECATED_TITLE);
+      await seedStatusEntry(store, identity.projectId, "superseded", SUPERSEDED_TITLE);
+      setProjectMemoryStoreForTest(store);
+
+      const tools = createProjectMemoryLookupTool(createContext(directory));
+      const defaultOutput = await executeTool(tools.project_memory_lookup, { query: QUERY, limit: LIMIT });
+      const archivedOutput = await executeTool(tools.project_memory_lookup, {
+        query: QUERY,
+        status: "archived",
+        limit: LIMIT,
+      });
+
+      expect(defaultOutput).toContain(ACTIVE_TITLE);
+      expect(defaultOutput).not.toContain(ARCHIVED_TITLE);
+      expect(defaultOutput).not.toContain(TOMBSTONED_TITLE);
+      expect(defaultOutput).not.toContain(DEPRECATED_TITLE);
+      expect(defaultOutput).not.toContain(SUPERSEDED_TITLE);
+      expect(archivedOutput).toContain(ARCHIVED_TITLE);
+      expect(archivedOutput).not.toContain(ACTIVE_TITLE);
+    },
+    PROJECT_MEMORY_TOOL_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "looks up an explicit project origin from a non-project directory",
+    async () => {
+      directory = mkdtempSync(join(tmpdir(), "pm-lookup-tool-target-"));
+      const fallbackIdentity = await resolveProjectId(directory);
+      const targetProjectId = projectIdForSource(ORIGIN_SOURCE);
+      const store = createProjectMemoryStore({ dbDir: join(directory, "memory") });
+      await store.initialize();
+      await store.upsertEntity(entity(targetProjectId));
+      await store.upsertEntry(entry(targetProjectId, { title: TARGET_TITLE }));
+      await store.upsertEntity(entity(fallbackIdentity.projectId, { name: "fallback" }));
+      await store.upsertEntry(entry(fallbackIdentity.projectId, { title: ACTIVE_TITLE }));
+      setProjectMemoryStoreForTest(store);
+
+      const tools = createProjectMemoryLookupTool(createContext(directory));
+      const output = await executeTool(tools.project_memory_lookup, {
+        query: QUERY,
+        project_origin: ORIGIN_URL,
+        limit: LIMIT,
+      });
+
+      expect(output).toContain(TARGET_TITLE);
+      expect(output).not.toContain(ACTIVE_TITLE);
+    },
+    PROJECT_MEMORY_TOOL_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "resolves registry aliases and worktrees to the origin-backed project",
+    async () => {
+      directory = mkdtempSync(join(tmpdir(), "pm-lookup-tool-registry-"));
+      const worktree = join(directory, "worktree");
+      const targetProjectId = projectIdForSource(ORIGIN_SOURCE);
+      const fallbackIdentity = await resolveProjectId(directory);
+      const store = createProjectMemoryStore({ dbDir: join(directory, "memory") });
+      await store.initialize();
+      await store.upsertEntity(entity(targetProjectId));
+      await store.upsertEntry(entry(targetProjectId, { title: ALIAS_TARGET_TITLE }));
+      await store.upsertEntity(entity(fallbackIdentity.projectId, { name: "fallback" }));
+      await store.upsertEntry(entry(fallbackIdentity.projectId, { title: ACTIVE_TITLE }));
+      setProjectMemoryStoreForTest(store);
+      (config.projectMemory as { registryFile: string }).registryFile = join(directory, "registry.json");
+      const registry = createProjectRegistry({ filePath: config.projectMemory.registryFile });
+      await registry.upsert({
+        projectId: targetProjectId,
+        origin: ORIGIN_URL,
+        aliases: [PROJECT_ALIAS],
+        worktrees: [worktree],
+        updatedAt: UPDATED_AT,
+      });
+
+      const tools = createProjectMemoryLookupTool(createContext(directory));
+      const aliasOutput = await executeTool(tools.project_memory_lookup, {
+        query: QUERY,
+        project_alias: PROJECT_ALIAS,
+        limit: LIMIT,
+      });
+      const worktreeOutput = await executeTool(tools.project_memory_lookup, {
+        query: QUERY,
+        project_worktree: worktree,
+        limit: LIMIT,
+      });
+
+      expect(aliasOutput).toContain(ALIAS_TARGET_TITLE);
+      expect(aliasOutput).not.toContain(ACTIVE_TITLE);
+      expect(worktreeOutput).toContain(ALIAS_TARGET_TITLE);
+      expect(worktreeOutput).not.toContain(ACTIVE_TITLE);
     },
     PROJECT_MEMORY_TOOL_TEST_TIMEOUT_MS,
   );

--- a/tests/tools/project-memory/maintain.test.ts
+++ b/tests/tools/project-memory/maintain.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { PluginInput } from "@opencode-ai/plugin";
+import type { ToolContext, ToolResult } from "@opencode-ai/plugin/tool";
+import { $ } from "bun";
+
+import {
+  createProjectMemoryStore,
+  type Entity,
+  type Entry,
+  type ProjectMemoryStore,
+  type Source,
+} from "@/project-memory";
+import { DEFAULT_MAINTENANCE_STALE_AFTER_MS } from "@/project-memory/maintenance/classifier";
+import { readMaintenanceJournal } from "@/project-memory/maintenance/journal";
+import { createProjectMemoryMaintainTool } from "@/tools/project-memory/maintain";
+import { resetProjectMemoryRuntimeForTest, setProjectMemoryStoreForTest } from "@/tools/project-memory/runtime";
+import { config } from "@/utils/config";
+import { type ProjectIdentity, resolveProjectId } from "@/utils/project-id";
+
+const TOOL_CONTEXT = {} as unknown as ToolContext;
+const REMOTE = "https://github.com/Wuxie233/micode.git";
+const ENTITY_ID = "entity-one";
+const ARCHIVE_ENTRY_ID = "entry-archive";
+const DUPLICATE_OLD_ID = "entry-duplicate-old";
+const DUPLICATE_NEW_ID = "entry-duplicate-new";
+const REVIEW_ENTRY_ID = "entry-review";
+const CREATED_AT = 1;
+const NOW = 2_000_000_000;
+const OLD = NOW - DEFAULT_MAINTENANCE_STALE_AFTER_MS - 1;
+const RECENT = NOW - 1_000;
+const EXPECTED_APPLIED = 3;
+
+type ExecuteSignature = (raw: unknown, ctx: ToolContext) => Promise<ToolResult>;
+
+let root: string;
+let workdir: string;
+let store: ProjectMemoryStore;
+let identity: ProjectIdentity;
+let originalRegistryFile: string;
+let originalJournalDir: string;
+
+beforeEach(async () => {
+  root = mkdtempSync(join(tmpdir(), "pm-maintain-tool-"));
+  workdir = join(root, "repo");
+  mkdirSync(workdir);
+  originalRegistryFile = config.projectMemory.registryFile;
+  originalJournalDir = config.projectMemory.maintenanceJournalDir;
+  (config.projectMemory as { registryFile: string; maintenanceJournalDir: string }).registryFile = join(
+    root,
+    "registry.json",
+  );
+  (config.projectMemory as { registryFile: string; maintenanceJournalDir: string }).maintenanceJournalDir = join(
+    root,
+    "journal",
+  );
+  await $`git init -q`.cwd(workdir);
+  await $`git remote add origin ${REMOTE}`.cwd(workdir);
+  identity = await resolveProjectId(workdir);
+  store = createProjectMemoryStore({ dbDir: join(root, "db") });
+  await store.initialize();
+  setProjectMemoryStoreForTest(store);
+});
+
+afterEach(async () => {
+  await resetProjectMemoryRuntimeForTest();
+  (config.projectMemory as { registryFile: string; maintenanceJournalDir: string }).registryFile = originalRegistryFile;
+  (config.projectMemory as { registryFile: string; maintenanceJournalDir: string }).maintenanceJournalDir =
+    originalJournalDir;
+  rmSync(root, { recursive: true, force: true });
+});
+
+function stringify(outcome: ToolResult): string {
+  if (typeof outcome === "string") return outcome;
+  return outcome.output;
+}
+
+async function executeMaintain(args: unknown, directory = workdir): Promise<string> {
+  const tools = createProjectMemoryMaintainTool({ directory } as unknown as PluginInput);
+  const exec = tools.project_memory_maintain.execute.bind(tools.project_memory_maintain) as unknown as ExecuteSignature;
+  return stringify(await exec(args, TOOL_CONTEXT));
+}
+
+function entity(overrides: Partial<Entity> = {}): Entity {
+  return {
+    projectId: identity.projectId,
+    id: ENTITY_ID,
+    kind: "module",
+    name: "auth",
+    createdAt: CREATED_AT,
+    updatedAt: CREATED_AT,
+    ...overrides,
+  };
+}
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    projectId: identity.projectId,
+    id: ARCHIVE_ENTRY_ID,
+    entityId: ENTITY_ID,
+    type: "note",
+    title: "Stable note",
+    summary: "A useful project memory note.",
+    status: "deprecated",
+    sensitivity: "internal",
+    createdAt: CREATED_AT,
+    updatedAt: OLD,
+    ...overrides,
+  };
+}
+
+function source(entryId: string, overrides: Partial<Source> = {}): Source {
+  return {
+    projectId: identity.projectId,
+    id: `source-${entryId}`,
+    entryId,
+    kind: "manual",
+    pointer: `manual://${entryId}`,
+    createdAt: RECENT,
+    ...overrides,
+  };
+}
+
+async function seedMaintenanceCandidates(): Promise<void> {
+  await store.upsertEntity(entity());
+  await store.upsertEntry(entry({ id: ARCHIVE_ENTRY_ID, title: "Archive me", status: "deprecated", updatedAt: OLD }));
+  await store.upsertEntry(
+    entry({ id: DUPLICATE_OLD_ID, title: "Duplicate", summary: "same text", status: "active", updatedAt: OLD }),
+  );
+  await store.upsertEntry(
+    entry({ id: DUPLICATE_NEW_ID, title: "Duplicate", summary: "same text", status: "active", updatedAt: RECENT }),
+  );
+  await store.upsertEntry(
+    entry({ id: REVIEW_ENTRY_ID, type: "decision", title: "Review old decision", status: "active", updatedAt: OLD }),
+  );
+  await store.upsertSource(source(ARCHIVE_ENTRY_ID));
+  await store.upsertSource(source(DUPLICATE_OLD_ID));
+  await store.upsertSource(source(DUPLICATE_NEW_ID));
+  await store.upsertSource(source(REVIEW_ENTRY_ID));
+}
+
+describe("project_memory_maintain tool", () => {
+  it("defaults to a manual dry-run and does not mutate project memory", async () => {
+    await seedMaintenanceCandidates();
+
+    const output = await executeMaintain({});
+
+    expect(output).toContain("## Project memory maintenance plan");
+    expect(output).toContain("- **Dry run:** true");
+    expect(output).toContain("| Entry ID | Action | Kind | Safe | Reason |");
+    expect(await store.loadEntry(identity.projectId, ARCHIVE_ENTRY_ID)).toMatchObject({ status: "deprecated" });
+    expect(await store.loadEntry(identity.projectId, DUPLICATE_OLD_ID)).toMatchObject({ status: "active" });
+    expect(await readMaintenanceJournal(identity.projectId)).toEqual([]);
+  });
+
+  it("applies safe archive and supersede actions when dry_run is false", async () => {
+    await seedMaintenanceCandidates();
+
+    const output = await executeMaintain({ dry_run: false });
+
+    expect(output).toContain("## Project memory maintenance applied");
+    expect(output).toContain(`- **Applied:** ${EXPECTED_APPLIED}`);
+    expect(output).toContain("- **Skipped:** 0");
+    expect(output).toContain("- **Blocked:** 1");
+    expect(output).toContain("- **Journal:** `");
+    expect(await store.loadEntry(identity.projectId, ARCHIVE_ENTRY_ID)).toMatchObject({ status: "archived" });
+    expect(await store.loadEntry(identity.projectId, DUPLICATE_OLD_ID)).toMatchObject({ status: "superseded" });
+    expect(await store.loadEntry(identity.projectId, REVIEW_ENTRY_ID)).toMatchObject({ status: "active" });
+    expect(await readMaintenanceJournal(identity.projectId)).toHaveLength(4);
+  });
+
+  it("returns a friendly degraded identity error without running the worker", async () => {
+    const plainDirectory = join(root, "plain");
+    mkdirSync(plainDirectory);
+    await seedMaintenanceCandidates();
+
+    const output = await executeMaintain({ dry_run: false }, plainDirectory);
+
+    expect(output).toContain("## Error");
+    expect(output.toLowerCase()).toContain("degraded identity");
+    expect(output).toContain("Configure a stable git origin or pass an explicit project origin.");
+    expect(await store.loadEntry(identity.projectId, ARCHIVE_ENTRY_ID)).toMatchObject({ status: "deprecated" });
+  });
+});

--- a/tests/tools/project-memory/promote.test.ts
+++ b/tests/tools/project-memory/promote.test.ts
@@ -7,12 +7,16 @@ import type { ToolContext, ToolResult } from "@opencode-ai/plugin/tool";
 import { $ } from "bun";
 
 import { createProjectMemoryStore, type ProjectMemoryStore } from "@/project-memory";
+import { createProjectRegistry } from "@/project-memory/registry";
 import { createProjectMemoryPromoteTool } from "@/tools/project-memory/promote";
 import { resetProjectMemoryRuntimeForTest, setProjectMemoryStoreForTest } from "@/tools/project-memory/runtime";
-import { resolveProjectId } from "@/utils/project-id";
+import { config } from "@/utils/config";
+import { projectIdForSource, resolveProjectId } from "@/utils/project-id";
 
 const TOOL_CONTEXT = {} as unknown as ToolContext;
 const ORIGIN_URL = "https://github.com/Wuxie233/micode.git";
+const OTHER_ORIGIN_URL = "https://github.com/Wuxie233/other-project.git";
+const OTHER_ORIGIN_SOURCE = "github.com/wuxie233/other-project";
 const ENTITY_NAME = "auth";
 const POINTER = "thoughts/lifecycle/42.md";
 const ACCEPTED_DECISION = "Cache permission lookups for 30s";
@@ -25,9 +29,12 @@ const PROMOTION_MARKDOWN = `## Decisions
 `;
 const EXPECTED_ACCEPTED = 1;
 const PROJECT_MEMORY_TOOL_TEST_TIMEOUT_MS = 20_000;
+const ALIAS = "registered-project";
+const UPDATED_AT = 1_234;
 
 let root: string;
 let store: ProjectMemoryStore;
+let originalRegistryFile: string;
 
 const stringify = (outcome: ToolResult): string => {
   if (typeof outcome === "string") return outcome;
@@ -59,12 +66,15 @@ function createPlainDirectory(): string {
 
 beforeEach(() => {
   root = mkdtempSync(join(tmpdir(), "project-memory-promote-tool-"));
+  originalRegistryFile = config.projectMemory.registryFile;
+  (config.projectMemory as { registryFile: string }).registryFile = join(root, "registry.json");
   store = createProjectMemoryStore({ dbDir: join(root, "db") });
   setProjectMemoryStoreForTest(store);
 });
 
 afterEach(async () => {
   await resetProjectMemoryRuntimeForTest();
+  (config.projectMemory as { registryFile: string }).registryFile = originalRegistryFile;
   rmSync(root, { recursive: true, force: true });
 });
 
@@ -111,6 +121,134 @@ describe("project_memory_promote tool", () => {
       expect(output).toContain("## Project memory promotion refused");
       expect(output.toLowerCase()).toContain("degraded identity");
       expect(await store.countEntries(identity.projectId)).toBe(0);
+    },
+    PROJECT_MEMORY_TOOL_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "promotes from a non-project directory when an explicit origin target is supplied",
+    async () => {
+      const directory = createPlainDirectory();
+      const toolDef = createProjectMemoryPromoteTool(createCtx(directory)).project_memory_promote;
+
+      const output = await callExecute(toolDef, {
+        markdown: `## Decisions\n- ${ACCEPTED_DECISION}\n`,
+        entity_name: ENTITY_NAME,
+        source_kind: "lifecycle",
+        pointer: POINTER,
+        project_origin: OTHER_ORIGIN_URL,
+      });
+      const fallbackIdentity = await resolveProjectId(directory);
+      const targetProjectId = projectIdForSource(OTHER_ORIGIN_SOURCE);
+
+      expect(output).toContain("## Project memory promoted");
+      expect(await store.countEntries(targetProjectId)).toBe(EXPECTED_ACCEPTED);
+      expect(await store.countEntries(fallbackIdentity.projectId)).toBe(0);
+    },
+    PROJECT_MEMORY_TOOL_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "returns a friendly refusal for ambiguous registry targets and does not write",
+    async () => {
+      const directory = createPlainDirectory();
+      const toolDef = createProjectMemoryPromoteTool(createCtx(directory)).project_memory_promote;
+      const registry = createProjectRegistry({ filePath: config.projectMemory.registryFile });
+      await registry.upsert({
+        projectId: "project-one",
+        origin: ORIGIN_URL,
+        aliases: [ALIAS],
+        worktrees: [],
+        updatedAt: UPDATED_AT,
+      });
+      await registry.upsert({
+        projectId: "project-two",
+        origin: OTHER_ORIGIN_URL,
+        aliases: [ALIAS],
+        worktrees: [],
+        updatedAt: UPDATED_AT,
+      });
+
+      const output = await callExecute(toolDef, {
+        markdown: `## Decisions\n- ${ACCEPTED_DECISION}\n`,
+        entity_name: ENTITY_NAME,
+        source_kind: "lifecycle",
+        pointer: POINTER,
+        project_alias: ALIAS,
+      });
+      const firstProjectId = projectIdForSource("github.com/wuxie233/micode");
+      const secondProjectId = projectIdForSource(OTHER_ORIGIN_SOURCE);
+
+      expect(output).toContain("## Error");
+      expect(output.toLowerCase()).toContain("ambiguous");
+      expect(output).toContain(`project_alias=${ALIAS}`);
+      expect(output).not.toContain("Error:");
+      expect(await store.countEntries(firstProjectId)).toBe(0);
+      expect(await store.countEntries(secondProjectId)).toBe(0);
+    },
+    PROJECT_MEMORY_TOOL_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "promotes by project alias through the registry instead of hashing the alias",
+    async () => {
+      const directory = createPlainDirectory();
+      const toolDef = createProjectMemoryPromoteTool(createCtx(directory)).project_memory_promote;
+      const registry = createProjectRegistry({ filePath: config.projectMemory.registryFile });
+      await registry.upsert({
+        projectId: "registered-project-id",
+        origin: OTHER_ORIGIN_URL,
+        aliases: [ALIAS],
+        worktrees: [],
+        updatedAt: UPDATED_AT,
+      });
+
+      const output = await callExecute(toolDef, {
+        markdown: `## Decisions\n- ${ACCEPTED_DECISION}\n`,
+        entity_name: ENTITY_NAME,
+        source_kind: "lifecycle",
+        pointer: POINTER,
+        project_alias: ALIAS,
+      });
+      const registeredProjectId = projectIdForSource(OTHER_ORIGIN_SOURCE);
+      const aliasProjectId = projectIdForSource(ALIAS);
+
+      expect(output).toContain("## Project memory promoted");
+      expect(await store.countEntries(registeredProjectId)).toBe(EXPECTED_ACCEPTED);
+      expect(await store.countEntries(aliasProjectId)).toBe(0);
+    },
+    PROJECT_MEMORY_TOOL_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "promotes by project worktree through the registry instead of hashing the path",
+    async () => {
+      const directory = createPlainDirectory();
+      const registeredWorktree = join(root, "registered-worktree");
+      mkdirSync(registeredWorktree);
+      const toolDef = createProjectMemoryPromoteTool(createCtx(directory)).project_memory_promote;
+      const registry = createProjectRegistry({ filePath: config.projectMemory.registryFile });
+      await registry.upsert({
+        projectId: "registered-project-id",
+        origin: OTHER_ORIGIN_URL,
+        aliases: [],
+        worktrees: [registeredWorktree],
+        updatedAt: UPDATED_AT,
+      });
+
+      const output = await callExecute(toolDef, {
+        markdown: `## Decisions\n- ${ACCEPTED_DECISION}\n`,
+        entity_name: ENTITY_NAME,
+        source_kind: "lifecycle",
+        pointer: POINTER,
+        project_worktree: registeredWorktree,
+      });
+      const registeredProjectId = projectIdForSource(OTHER_ORIGIN_SOURCE);
+      const pathProjectId = projectIdForSource(registeredWorktree);
+
+      expect(output).toContain("## Project memory promoted");
+      expect(await store.countEntries(registeredProjectId)).toBe(EXPECTED_ACCEPTED);
+      expect(await store.countEntries(pathProjectId)).toBe(0);
     },
     PROJECT_MEMORY_TOOL_TEST_TIMEOUT_MS,
   );

--- a/tests/tools/project-memory/runtime-identity.test.ts
+++ b/tests/tools/project-memory/runtime-identity.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createProjectRegistry } from "@/project-memory/registry";
+import {
+  getIdentity,
+  getReadIdentity,
+  getWriteIdentity,
+  resetProjectMemoryRuntimeForTest,
+} from "@/tools/project-memory/runtime";
+import { config } from "@/utils/config";
+import { normalizeProjectOrigin, projectIdForSource } from "@/utils/project-id";
+
+const ORIGIN = "https://github.com/Wuxie233/micode.git";
+const OTHER_ORIGIN = "git@github.com:Wuxie233/other.git";
+const ALIAS = "micode";
+const UPDATED_AT = 1_234;
+
+let root: string;
+let originalRegistryFile: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "pm-runtime-identity-"));
+  originalRegistryFile = config.projectMemory.registryFile;
+  (config.projectMemory as { registryFile: string }).registryFile = join(root, "registry.json");
+});
+
+afterEach(async () => {
+  await resetProjectMemoryRuntimeForTest();
+  (config.projectMemory as { registryFile: string }).registryFile = originalRegistryFile;
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("project memory runtime identity", () => {
+  it("keeps getIdentity as a read identity alias for old callers", async () => {
+    const directory = mkdtempSync(join(root, "plain-"));
+
+    await expect(getIdentity(directory)).resolves.toEqual(await getReadIdentity(directory));
+  });
+
+  it("rejects writes when only a path-degraded identity is available", async () => {
+    const directory = mkdtempSync(join(root, "plain-write-"));
+
+    await expect(getWriteIdentity(directory)).rejects.toThrow("degraded identity");
+  });
+
+  it("resolves an explicit origin from a non-project directory", async () => {
+    const directory = mkdtempSync(join(root, "plain-origin-"));
+    const source = normalizeProjectOrigin(ORIGIN);
+
+    await expect(getWriteIdentity(directory, { project_origin: ORIGIN })).resolves.toEqual({
+      projectId: projectIdForSource(source),
+      kind: "origin",
+      source,
+    });
+  });
+
+  it("rejects ambiguous registry targets for writes", async () => {
+    const directory = mkdtempSync(join(root, "plain-registry-"));
+    const registry = createProjectRegistry({ filePath: config.projectMemory.registryFile });
+
+    await registry.upsert({
+      projectId: "project-one",
+      origin: ORIGIN,
+      aliases: [ALIAS],
+      worktrees: [],
+      updatedAt: UPDATED_AT,
+    });
+    await registry.upsert({
+      projectId: "project-two",
+      origin: OTHER_ORIGIN,
+      aliases: [ALIAS],
+      worktrees: [],
+      updatedAt: UPDATED_AT,
+    });
+
+    await expect(getWriteIdentity(directory, { project_alias: ALIAS })).rejects.toThrow("ambiguous project target");
+  });
+
+  it("rejects conflicting explicit and lifecycle origins", async () => {
+    const directory = mkdtempSync(join(root, "plain-conflict-"));
+
+    await expect(
+      getWriteIdentity(directory, {
+        project_origin: ORIGIN,
+        lifecycle_project_origin: OTHER_ORIGIN,
+      }),
+    ).rejects.toThrow("ambiguous project target");
+  });
+
+  it("rejects unknown explicit aliases instead of falling back to current directory", async () => {
+    const directory = mkdtempSync(join(root, "plain-unknown-alias-"));
+
+    await expect(getWriteIdentity(directory, { project_alias: "missing-alias" })).rejects.toThrow(
+      "unknown project target",
+    );
+  });
+
+  it("rejects unknown explicit worktrees instead of falling back to current directory", async () => {
+    const directory = mkdtempSync(join(root, "plain-unknown-worktree-"));
+
+    await expect(getWriteIdentity(directory, { project_worktree: join(root, "missing-worktree") })).rejects.toThrow(
+      "unknown project target",
+    );
+  });
+});

--- a/tests/utils/config.test.ts
+++ b/tests/utils/config.test.ts
@@ -227,6 +227,13 @@ describe("config utility", () => {
       expect(config.projectMemory.storageDir).toMatch(/\.config\/opencode\/project-memory$/);
     });
 
+    it("exposes registry and maintenance journal paths under the project-memory config root", () => {
+      expect(config.projectMemory.registryFile).toMatch(/\.config\/opencode\/project-memory\/registry\.json$/);
+      expect(config.projectMemory.maintenanceJournalDir).toMatch(
+        /\.config\/opencode\/project-memory\/maintenance-journal$/,
+      );
+    });
+
     it("declares the sensitivity vocabulary", () => {
       expect(config.projectMemory.sensitivity).toEqual(["public", "internal", "secret"]);
     });
@@ -235,8 +242,30 @@ describe("config utility", () => {
       expect(config.projectMemory.statuses).toEqual(["active", "superseded", "tentative", "hypothesis", "deprecated"]);
     });
 
+    it("declares default lookup and historical status groups", () => {
+      expect(config.projectMemory.defaultLookupStatuses).toEqual(["active"]);
+      expect(config.projectMemory.historicalStatuses).toEqual([
+        "active",
+        "superseded",
+        "tentative",
+        "hypothesis",
+        "deprecated",
+      ]);
+    });
+
     it("defaults the lookup result limit to 10", () => {
       expect(config.projectMemory.defaultLookupLimit).toBe(10);
+    });
+
+    it("keeps lifecycle promotion disabled while enabling maintenance triggers", () => {
+      expect(config.projectMemory.promoteOnLifecycleFinish).toBe(false);
+      expect(config.projectMemory.maintenanceEnabled).toBe(true);
+      expect(config.projectMemory.maintenanceTerminalTriggerEnabled).toBe(true);
+    });
+
+    it("declares maintenance tuning defaults", () => {
+      expect(config.projectMemory.maintenanceLockTtlMs).toBe(600_000);
+      expect(config.projectMemory.maintenanceSnapshotLimit).toBe(200);
     });
   });
 

--- a/tests/utils/project-id.test.ts
+++ b/tests/utils/project-id.test.ts
@@ -4,7 +4,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { $ } from "bun";
 
-import { resolveProjectId } from "@/utils/project-id";
+import {
+  isDegradedProjectIdentity,
+  normalizeProjectOrigin,
+  projectIdForSource,
+  resolveProjectId,
+} from "@/utils/project-id";
 
 let workdir: string;
 
@@ -49,5 +54,58 @@ describe("resolveProjectId", () => {
     } finally {
       rmSync(plain, { recursive: true, force: true });
     }
+  });
+});
+
+describe("normalizeProjectOrigin", () => {
+  it("normalizes HTTPS origins", () => {
+    expect(normalizeProjectOrigin(" https://GitHub.com/Wuxie233/micode.git ")).toBe("github.com/wuxie233/micode");
+  });
+
+  it("normalizes SSH origins", () => {
+    expect(normalizeProjectOrigin("git@GitHub.com:Wuxie233/micode.git")).toBe("github.com/wuxie233/micode");
+  });
+
+  it("normalizes mixed-case URL host and path", () => {
+    expect(normalizeProjectOrigin("HTTPS://GitHub.COM/Wuxie233/MiCode.GIT")).toBe("github.com/wuxie233/micode");
+  });
+
+  it("normalizes non-URL fallback without owner/name rewriting", () => {
+    expect(normalizeProjectOrigin(" Wuxie233/MiCode.git ")).toBe("wuxie233/micode");
+  });
+
+  it("does not remove fork parent or rewrite owner", () => {
+    expect(normalizeProjectOrigin("https://github.com/ForkOwner/micode.git")).toBe("github.com/forkowner/micode");
+    expect(normalizeProjectOrigin("https://github.com/ParentOwner/micode.git")).toBe("github.com/parentowner/micode");
+  });
+});
+
+describe("projectIdForSource", () => {
+  it("returns a stable 16-character sha1 hex prefix", () => {
+    const source = "github.com/wuxie233/micode";
+    const a = projectIdForSource(source);
+    const b = projectIdForSource(source);
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{16}$/);
+    expect(projectIdForSource("github.com/other/micode")).not.toBe(a);
+  });
+});
+
+describe("isDegradedProjectIdentity", () => {
+  it("treats non-origin identities as degraded", () => {
+    expect(
+      isDegradedProjectIdentity({
+        projectId: projectIdForSource("github.com/wuxie233/micode"),
+        kind: "origin",
+        source: "github.com/wuxie233/micode",
+      }),
+    ).toBe(false);
+    expect(
+      isDegradedProjectIdentity({
+        projectId: projectIdForSource(workdir),
+        kind: "path",
+        source: workdir,
+      }),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Add deterministic Project Memory target resolution beyond cwd, including explicit target, lifecycle/session context, registry, and safe fallback behavior.
- Add Project Memory maintenance worker for soft cleanup, archiving, tombstoning, journaling, and non-blocking lifecycle terminal scheduling.
- Keep default lookup clean by excluding archived/tombstoned/deprecated/superseded entries unless explicitly requested.

## Verification
- bun run lint
- bun run typecheck
- Project Memory resolver, lookup filter, maintenance worker, trigger, lifecycle boundary, and integration test suites passed in executor report.

Issue: #83