### PR TITLE
feat(context-capsule): Working Context Capsule for subagent prompt cache reuse (#91)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ micode 在主工作流（brainstormer / planner / executor）和对抗审查（c
 1. **预期表现**：用户现在会看到什么行为。1 句话或 2-3 个 bullet，说"是什么"不说"改了哪个文件"。
 2. **你可以怎么验收**：用户用 2-4 个步骤自己验证（打开某页 / 跑某命令 / 检查某输出），不是 agent 内部 verify 脚本。
 3. **已知限制 / 下一步**：没完成的部分、需要用户手动处理的事、已知边界。没有就写"无"。
-4. **本次知识上下文**：本任务读取/确认/维护了哪些 Atlas 节点、Project Memory 条目、Mindmodel 主题，传给子 agent 的 context-brief 摘要长度。段尾两行固定状态：`Atlas status: <value>` 和 `Project Memory status: <value>`。
+4. **本次知识上下文**：本任务读取/确认/维护了哪些 Atlas 节点、Project Memory 条目、Mindmodel 主题，传给子 agent 的 context-brief 摘要长度。段尾三行固定状态：`Atlas status: <value>`、`Project Memory status: <value>` 和 `Capsule status: <value>`；Capsule status 取值为 `none|fresh|partially-stale|discarded|skipped:<reason>|blocked:<reason>`。
 5. **实现记录**：commit / 测试 / issue / batch / 子任务等过程产物压缩为 1-2 行。
 
 ### Blocked / failed-stop 例外

--- a/src/agents/atlas-initializer.ts
+++ b/src/agents/atlas-initializer.ts
@@ -1,5 +1,7 @@
 import type { AgentConfig } from "@opencode-ai/sdk";
 
+import { CONTEXT_CAPSULE_PROTOCOL } from "./context-capsule-protocol";
+
 const PROMPT = `
 <environment>
 You are running as part of the "micode" OpenCode plugin (NOT Claude Code).
@@ -41,6 +43,17 @@ Use spawn_agent (not Task) for all parallel worker invocations.
     - atlas/50-risks/ — Risks layer: known risks and mitigations
     - atlas/_meta/ — Internal: log/, challenges/ (not exposed to users)
   </output-layout>
+
+  ${CONTEXT_CAPSULE_PROTOCOL}
+
+  <context-capsule-usage>
+    Treat Context Capsule only as a hot-path prompt prefix for worker user prompts: the
+    capsule is not an atlas node and must never be written to atlas/ or reconciled as durable
+    atlas knowledge. When spawning parallel workers, pass the same contextCapsule object into
+    every worker prompt before task-specific deltas so cache reuse is possible. Preserve the
+    normal Atlas initializer discovery, worker fan-out, reconcile, write, maintenance-log,
+    atlas-only commit, and push flow.
+  </context-capsule-usage>
 
   <phase-plan>
     <phase name="0-preflight" description="Check for existing vault">

--- a/src/agents/brainstormer.ts
+++ b/src/agents/brainstormer.ts
@@ -1,6 +1,7 @@
 import type { AgentConfig } from "@opencode-ai/sdk";
 
 import { ATLAS_MENTAL_MODEL_PROTOCOL } from "./atlas-mental-model";
+import { CONTEXT_CAPSULE_PROTOCOL } from "./context-capsule-protocol";
 import { DECISION_MINIMAL_RESPONSE_PROTOCOL } from "./decision-minimal-response";
 import { KNOWLEDGE_CONTEXT_SECTION } from "./knowledge-context-section";
 import { LENS_SWARM_PROTOCOL } from "./lens-swarm-protocol";
@@ -310,6 +311,14 @@ emit exactly one line at the very top of your response:
 <rule>Specialists do not enter the executor reviewer loop. Their APPROVED / CHANGES REQUESTED / verdict text (when present) is human synthesis material, not loop control.</rule>
 <rule>Cap: at most 1 specialist suggestion per phase. Cap on simultaneous specialists: at most 2 in parallel when the user explicitly requests multiple. Diminishing returns and prompt fatigue beyond that.</rule>
 </specialist-dispatch>
+
+${CONTEXT_CAPSULE_PROTOCOL}
+
+<brainstormer-context-capsule-note priority="critical">
+<rule>Before Lens Swarm, critic/adversarial fan-out, and exploration fan-out, construct or reuse a context capsule as a cache-friendly user-prompt prefix for spawned scouts/critics/research subagents; keep task-specific deltas after the capsule.</rule>
+<rule>A→B reuse is allowed only when the capsule freshness preflight passes for the same lifecycle issue, branch, worktree, HEAD SHA, and source hashes; otherwise discard or skip the capsule and proceed with normal confirmed context.</rule>
+<rule>The capsule never replaces design judgment, context-brief, Project Memory, Atlas, or the delegated worker's obligation to verify its own evidence.</rule>
+</brainstormer-context-capsule-note>
 
 ${LENS_SWARM_PROTOCOL}
 

--- a/src/agents/commander.ts
+++ b/src/agents/commander.ts
@@ -1,6 +1,7 @@
 import type { AgentConfig } from "@opencode-ai/sdk";
 
 import { ATLAS_MENTAL_MODEL_PROTOCOL } from "./atlas-mental-model";
+import { CONTEXT_CAPSULE_PROTOCOL } from "./context-capsule-protocol";
 import { DECISION_MINIMAL_RESPONSE_PROTOCOL } from "./decision-minimal-response";
 import { KNOWLEDGE_CONTEXT_SECTION } from "./knowledge-context-section";
 import { LENS_SWARM_PROTOCOL } from "./lens-swarm-protocol";
@@ -312,6 +313,14 @@ ${DECISION_MINIMAL_RESPONSE_PROTOCOL}
 ${ATLAS_MENTAL_MODEL_PROTOCOL}
 
 ${PROJECT_MEMORY_PROTOCOL}
+
+${CONTEXT_CAPSULE_PROTOCOL}
+
+<commander-context-capsule-note priority="critical">
+<rule>For exploration fan-out and same-lifecycle sequential work, preserve capsule semantics: treat the capsule as a cache-friendly user-prompt prefix only, not durable memory and not a replacement for the delegated agent's context-brief.</rule>
+<rule>A→B capsule reuse is only allowed when the lifecycle issue, branch, worktree, HEAD SHA, and source hashes pass freshness checks; otherwise discard or skip the capsule and continue with normal confirmed context.</rule>
+<rule>User-facing terminal reports must stay decision-minimal while still surfacing the freshness result as Capsule status: <none|fresh|partially-stale|discarded|skipped:<reason>|blocked:<reason>> in 本次知识上下文.</rule>
+</commander-context-capsule-note>
 
 <atlas-commander-rule priority="low">
 <rule>For quick-op routes (lookup / status / single-line patch / version bump), the default Atlas status is no-change. Do not consult atlas_lookup unless the request actually touches modules, behaviour, decisions, or risks.</rule>

--- a/src/agents/context-capsule-protocol.ts
+++ b/src/agents/context-capsule-protocol.ts
@@ -1,0 +1,26 @@
+export const CONTEXT_CAPSULE_PROTOCOL = `<context-capsule-protocol priority="critical" description="Immutable hot-path context prefix for subagent prompt cache reuse">
+<purpose>
+The Context Capsule is an immutable, short-lived hot-path artifact that carries already-read and already-confirmed facts into subagent user prompts. It is not durable knowledge, not Project Memory, not Atlas, not a replacement for context-brief, and not a live subagent session fork.
+</purpose>
+
+<injection-contract>
+- Inject the capsule into the user prompt TOP, before spawn-meta, before context-brief, before task-specific instructions.
+- Never inject capsule content into a system prompt or agent definition.
+- The exact <context-capsule>...</context-capsule> block for one fan-out MUST be byte-identical across every parallel worker so provider prompt cache can hit.
+- Task-specific deltas stay after the capsule. Existing <context-brief> remains the per-task executor/reviewer contract and must not be replaced by the capsule.
+</injection-contract>
+
+<reuse-boundary>
+- A→B reuse is allowed only for the same lifecycle issue, same branch, and same worktree.
+- Freshness preflight checks lifecycle issue, branch, HEAD SHA, worktree, and source file hashes before reuse.
+- Freshness result must be surfaced as Capsule status: <none|fresh|partially-stale|discarded|skipped:<reason>|blocked:<reason>>.
+</reuse-boundary>
+
+<safety-boundary>
+- Secret filtering is mandatory before writing any capsule file.
+- Do not write Authorization headers, tokens, private URLs, .env style values, raw logs, or credentials into a capsule.
+- Capsule is not durable knowledge: do not promote it to Project Memory, do not write it into Atlas, and do not treat it as a long-term source of truth.
+- The worker still must read its own target files before editing or reviewing. Capsule facts are a warm start, not the final evidence source.
+- Do not extend resume_subagent, do not fork live sessions, and do not change lifecycle recovery semantics for capsule reuse.
+</safety-boundary>
+</context-capsule-protocol>`;

--- a/src/agents/context-capsule/builder.ts
+++ b/src/agents/context-capsule/builder.ts
@@ -1,0 +1,127 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { createCapsuleToken, hashText, renderCapsuleDocument, slugifyCapsuleTopic } from "./format";
+import { assertCapsuleSafe } from "./redact";
+import type {
+  BuildContextCapsuleResult,
+  BuiltContextCapsule,
+  ContextCapsuleBuildInput,
+  ContextCapsuleFrontmatter,
+} from "./types";
+
+const DEFAULT_OUTPUT_DIR = join("thoughts", "shared", "context-capsules");
+const SOFT_WINDOW_WARNING_THRESHOLD = 1;
+
+function getOutputDir(input: ContextCapsuleBuildInput): string {
+  return input.outputDir ?? join(input.worktree, DEFAULT_OUTPUT_DIR);
+}
+
+function buildSourceHashes(input: ContextCapsuleBuildInput): Readonly<Record<string, string>> {
+  return Object.fromEntries(input.sourceFiles.map((source) => [source.path, hashText(source.content)]));
+}
+
+function buildFrontmatter(input: ContextCapsuleBuildInput): ContextCapsuleFrontmatter {
+  return {
+    lifecycle_issue: input.lifecycleIssue,
+    branch: input.branch,
+    head_sha: input.headSha,
+    worktree: input.worktree,
+    created_at: (input.createdAt ?? new Date()).toISOString(),
+    source_files: input.sourceFiles.map((source) => source.path).sort(),
+    source_hashes: buildSourceHashes(input),
+  };
+}
+
+function renderBullets(values: readonly string[], emptyText: string): string {
+  if (values.length === 0) return `- ${emptyText}`;
+  return values.map((value) => `- ${value}`).join("\n");
+}
+
+function renderSourceFiles(frontmatter: ContextCapsuleFrontmatter): string {
+  if (frontmatter.source_files.length === 0) return "- none";
+  return frontmatter.source_files
+    .map((path) => `- \`${path}\` — sha256: ${frontmatter.source_hashes[path] ?? "missing"}`)
+    .join("\n");
+}
+
+function renderCapsuleBody(input: ContextCapsuleBuildInput, frontmatter: ContextCapsuleFrontmatter): string {
+  return [
+    "## Confirmed Facts",
+    "",
+    renderBullets(input.confirmedFacts, "none"),
+    "",
+    "## Source Files",
+    "",
+    renderSourceFiles(frontmatter),
+  ].join("\n");
+}
+
+function findUnsafeInput(input: ContextCapsuleBuildInput): { readonly scope: string; readonly reason: string } | null {
+  for (const fact of input.confirmedFacts) {
+    const result = assertCapsuleSafe(fact);
+    if (!result.ok) return { scope: "confirmedFacts", reason: result.match.reason };
+  }
+
+  for (const source of input.sourceFiles) {
+    const result = assertCapsuleSafe(source.content);
+    if (!result.ok) return { scope: `sourceFiles:${source.path}`, reason: result.match.reason };
+  }
+
+  return null;
+}
+
+function buildWarnings(input: ContextCapsuleBuildInput): readonly string[] {
+  if (input.softWindowRatio === undefined || input.softWindowRatio <= SOFT_WINDOW_WARNING_THRESHOLD) return [];
+  return [`soft_window_ratio: ${input.softWindowRatio}`];
+}
+
+function makeCapsulePath(outputDir: string, input: ContextCapsuleBuildInput, token: string): string {
+  const issuePrefix = input.lifecycleIssue === null ? "no-issue" : `issue-${input.lifecycleIssue}`;
+  const topicSlug = slugifyCapsuleTopic(input.topic);
+  return join(outputDir, `${issuePrefix}-${topicSlug}-${token}.md`);
+}
+
+function writeImmutableFile(path: string, document: string): void {
+  if (existsSync(path)) return;
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(path, document, "utf8");
+}
+
+export function buildContextCapsule(input: ContextCapsuleBuildInput): BuildContextCapsuleResult {
+  const unsafeInput = findUnsafeInput(input);
+  if (unsafeInput) {
+    return {
+      status: "blocked",
+      reason: "secret_detected",
+      detail: `${unsafeInput.scope}: ${unsafeInput.reason}`,
+    };
+  }
+
+  const frontmatter = buildFrontmatter(input);
+  const body = renderCapsuleBody(input, frontmatter);
+  const document = renderCapsuleDocument(frontmatter, body);
+  const safety = assertCapsuleSafe(document);
+  if (!safety.ok) {
+    return {
+      status: "blocked",
+      reason: "secret_detected",
+      detail: `document: ${safety.match.reason}`,
+    };
+  }
+
+  const token = createCapsuleToken(frontmatter);
+  const path = makeCapsulePath(getOutputDir(input), input, token);
+  writeImmutableFile(path, document);
+
+  const result: BuiltContextCapsule = {
+    status: "fresh",
+    path,
+    sha: hashText(document),
+    token,
+    frontmatter,
+    body,
+    document,
+    warnings: buildWarnings(input),
+  };
+  return result;
+}

--- a/src/agents/context-capsule/format.ts
+++ b/src/agents/context-capsule/format.ts
@@ -1,0 +1,76 @@
+import { createHash } from "node:crypto";
+import type { ContextCapsuleFrontmatter } from "./types";
+
+const FALLBACK_TOPIC = "context-capsule";
+const MAX_SLUG_LENGTH = 80;
+const CAPSULE_TOKEN_LENGTH = 16;
+
+export function hashText(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}
+
+export function slugifyCapsuleTopic(topic: string): string {
+  const slug = topic
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, MAX_SLUG_LENGTH);
+  return slug.length > 0 ? slug : FALLBACK_TOPIC;
+}
+
+function quoteYaml(value: string): string {
+  return JSON.stringify(value);
+}
+
+function renderStringArray(values: readonly string[]): string {
+  if (values.length === 0) return "[]";
+  return `\n${[...values]
+    .sort()
+    .map((value) => `  - ${quoteYaml(value)}`)
+    .join("\n")}`;
+}
+
+function renderStringRecord(values: Readonly<Record<string, string>>): string {
+  const entries = Object.entries(values).sort(([left], [right]) => left.localeCompare(right));
+  if (entries.length === 0) return "{}";
+  return `\n${entries.map(([key, value]) => `  ${quoteYaml(key)}: ${quoteYaml(value)}`).join("\n")}`;
+}
+
+export function renderCapsuleDocument(frontmatter: ContextCapsuleFrontmatter, body: string): string {
+  const normalized: ContextCapsuleFrontmatter = {
+    ...frontmatter,
+    source_files: [...frontmatter.source_files].sort(),
+    source_hashes: Object.fromEntries(
+      Object.entries(frontmatter.source_hashes).sort(([left], [right]) => left.localeCompare(right)),
+    ),
+  };
+
+  return [
+    "---",
+    `lifecycle_issue: ${normalized.lifecycle_issue ?? "null"}`,
+    `branch: ${quoteYaml(normalized.branch)}`,
+    `head_sha: ${quoteYaml(normalized.head_sha)}`,
+    `worktree: ${quoteYaml(normalized.worktree)}`,
+    `created_at: ${quoteYaml(normalized.created_at)}`,
+    `source_files:${renderStringArray(normalized.source_files)}`,
+    `source_hashes:${renderStringRecord(normalized.source_hashes)}`,
+    "---",
+    "",
+    body.trimEnd(),
+    "",
+  ].join("\n");
+}
+
+export function createCapsuleToken(frontmatter: ContextCapsuleFrontmatter): string {
+  return hashText(
+    JSON.stringify({
+      lifecycle_issue: frontmatter.lifecycle_issue,
+      branch: frontmatter.branch,
+      head_sha: frontmatter.head_sha,
+      worktree: frontmatter.worktree,
+      source_hashes: Object.fromEntries(
+        Object.entries(frontmatter.source_hashes).sort(([a], [b]) => a.localeCompare(b)),
+      ),
+    }),
+  ).slice(0, CAPSULE_TOKEN_LENGTH);
+}

--- a/src/agents/context-capsule/freshness.ts
+++ b/src/agents/context-capsule/freshness.ts
@@ -1,0 +1,67 @@
+import type { ContextCapsuleFreshnessInput, ContextCapsuleFreshnessResult } from "./types";
+
+const HARD_DISCARD_REASONS = ["lifecycle_issue_mismatch", "branch_mismatch", "worktree_mismatch"] as const;
+
+function sortedUnique(values: readonly string[]): readonly string[] {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right));
+}
+
+function findStaleSourceFiles(input: ContextCapsuleFreshnessInput): readonly string[] {
+  const sourceFiles = new Set([...input.frontmatter.source_files, ...Object.keys(input.frontmatter.source_hashes)]);
+
+  for (const sourceFile of Object.keys(input.sourceHashes)) {
+    sourceFiles.add(sourceFile);
+  }
+
+  return sortedUnique(
+    [...sourceFiles].filter(
+      (sourceFile) => input.frontmatter.source_hashes[sourceFile] !== input.sourceHashes[sourceFile],
+    ),
+  );
+}
+
+export function evaluateContextCapsuleFreshness(input: ContextCapsuleFreshnessInput): ContextCapsuleFreshnessResult {
+  const discardReasons: string[] = [];
+
+  if (input.frontmatter.lifecycle_issue !== input.expectedLifecycleIssue) {
+    discardReasons.push(HARD_DISCARD_REASONS[0]);
+  }
+  if (input.frontmatter.branch !== input.branch) {
+    discardReasons.push(HARD_DISCARD_REASONS[1]);
+  }
+  if (input.frontmatter.worktree !== input.worktree) {
+    discardReasons.push(HARD_DISCARD_REASONS[2]);
+  }
+
+  if (discardReasons.length > 0) {
+    return {
+      status: "discarded",
+      reasons: discardReasons,
+      staleSourceFiles: [],
+    };
+  }
+
+  const staleSourceFiles = findStaleSourceFiles(input);
+  const reasons: string[] = [];
+
+  if (input.frontmatter.head_sha !== input.headSha) {
+    reasons.push("head_sha_changed");
+  }
+  if (staleSourceFiles.length > 0) {
+    reasons.push("source_hashes_changed");
+  }
+
+  if (reasons.length > 0) {
+    return {
+      status: "partially-stale",
+      reasons,
+      staleSourceFiles,
+    };
+  }
+
+  return {
+    status: "fresh",
+    reasons: [],
+    staleSourceFiles: [],
+  };
+}

--- a/src/agents/context-capsule/index.ts
+++ b/src/agents/context-capsule/index.ts
@@ -1,0 +1,7 @@
+export * from "./builder";
+export * from "./format";
+export * from "./freshness";
+export * from "./injector";
+export * from "./redact";
+export * from "./store";
+export * from "./types";

--- a/src/agents/context-capsule/injector.ts
+++ b/src/agents/context-capsule/injector.ts
@@ -1,0 +1,30 @@
+import type { ContextCapsuleRef } from "./types";
+
+const FRONTMATTER_PATTERN = /^---\n[\s\S]*?\n---\n?/;
+
+function escapeAttribute(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+export function stripCapsuleFrontmatter(content: string): string {
+  return content.replace(FRONTMATTER_PATTERN, "").trimStart();
+}
+
+function capsuleBody(content: string): string {
+  return stripCapsuleFrontmatter(content).trimEnd();
+}
+
+export function renderContextCapsulePrefix(capsule: ContextCapsuleRef): string {
+  return [
+    `<context-capsule sha="${escapeAttribute(capsule.sha)}" fresh-token="${escapeAttribute(capsule.token)}" path="${escapeAttribute(capsule.path)}">`,
+    capsuleBody(capsule.content),
+    "</context-capsule>",
+    "",
+    "",
+  ].join("\n");
+}
+
+export function applyContextCapsulePrefix(prompt: string, capsule: ContextCapsuleRef | null | undefined): string {
+  if (!capsule) return prompt;
+  return `${renderContextCapsulePrefix(capsule)}${prompt}`;
+}

--- a/src/agents/context-capsule/redact.ts
+++ b/src/agents/context-capsule/redact.ts
@@ -1,0 +1,31 @@
+import { detectSecret, type SecretMatch } from "@/utils/secret-detect";
+
+export interface CapsuleSecretMatch extends SecretMatch {
+  readonly reason: string;
+}
+
+export type CapsuleSafetyResult = { readonly ok: true } | { readonly ok: false; readonly match: CapsuleSecretMatch };
+
+const EXTRA_PATTERNS: ReadonlyArray<{ readonly reason: string; readonly regex: RegExp }> = [
+  { reason: "authorization_header", regex: /^\s*Authorization\s*:\s*\S+/im },
+  {
+    reason: "env_secret_assignment",
+    regex: /^\s*[A-Z0-9_]*(?:API_KEY|TOKEN|SECRET|PASSWORD|PRIVATE_URL)[A-Z0-9_]*\s*=\s*\S+/im,
+  },
+  { reason: "credential_url", regex: /https?:\/\/[^\s/@:]+:[^\s/@]+@[^\s]+/i },
+  { reason: "raw_log_dump", regex: /BEGIN RAW LOG|END RAW LOG|^\[[0-9:. -]+\]\s+(?:DEBUG|TRACE|ERROR)/im },
+];
+
+export function findCapsuleSecret(text: string): CapsuleSecretMatch | null {
+  for (const { reason, regex } of EXTRA_PATTERNS) {
+    const match = regex.exec(text);
+    if (match) return { reason, index: match.index };
+  }
+  const generic = detectSecret(text);
+  return generic ? { reason: generic.reason, index: generic.index } : null;
+}
+
+export function assertCapsuleSafe(text: string): CapsuleSafetyResult {
+  const match = findCapsuleSecret(text);
+  return match ? { ok: false, match } : { ok: true };
+}

--- a/src/agents/context-capsule/store.ts
+++ b/src/agents/context-capsule/store.ts
@@ -1,0 +1,113 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { parse } from "yaml";
+import { createCapsuleToken, hashText } from "./format";
+import type { ContextCapsuleFrontmatter, ContextCapsuleRef } from "./types";
+
+export const DEFAULT_CONTEXT_CAPSULE_DIRECTORY = "thoughts/shared/context-capsules";
+
+const FRONTMATTER_OPEN = "---\n";
+const FRONTMATTER_CLOSE = "\n---";
+const FRONTMATTER_CLOSE_WITH_NEWLINE = "\n---\n";
+
+export interface ParsedContextCapsuleDocument {
+  readonly frontmatter: ContextCapsuleFrontmatter;
+  readonly body: string;
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function asStringArray(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string").sort();
+}
+
+function asStringRecord(value: unknown): Readonly<Record<string, string>> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter((entry): entry is [string, string] => typeof entry[1] === "string")
+      .sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+function normalizeLifecycleIssue(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) ? value : null;
+}
+
+function normalizeFrontmatter(value: unknown): ContextCapsuleFrontmatter {
+  const frontmatter = value && typeof value === "object" && !Array.isArray(value) ? value : {};
+  const record = frontmatter as Record<string, unknown>;
+
+  return {
+    lifecycle_issue: normalizeLifecycleIssue(record.lifecycle_issue),
+    branch: asString(record.branch),
+    head_sha: asString(record.head_sha),
+    worktree: asString(record.worktree),
+    created_at: asString(record.created_at),
+    source_files: asStringArray(record.source_files),
+    source_hashes: asStringRecord(record.source_hashes),
+  };
+}
+
+export function parseContextCapsuleDocument(document: string): ParsedContextCapsuleDocument {
+  if (!document.startsWith(FRONTMATTER_OPEN)) {
+    return { frontmatter: normalizeFrontmatter({}), body: document };
+  }
+
+  const end = document.indexOf(FRONTMATTER_CLOSE, FRONTMATTER_OPEN.length);
+  if (end === -1) {
+    return { frontmatter: normalizeFrontmatter({}), body: document };
+  }
+
+  const frontmatterText = document.slice(FRONTMATTER_OPEN.length, end);
+  let bodyStart = document.startsWith(FRONTMATTER_CLOSE_WITH_NEWLINE, end)
+    ? end + FRONTMATTER_CLOSE_WITH_NEWLINE.length
+    : end + FRONTMATTER_CLOSE.length;
+  if (document.startsWith("\n", bodyStart)) bodyStart += 1;
+  return {
+    frontmatter: normalizeFrontmatter(parse(frontmatterText)),
+    body: document.slice(bodyStart),
+  };
+}
+
+async function readCapsuleRef(path: string): Promise<(ContextCapsuleRef & { readonly createdAt: number }) | null> {
+  const content = await readFile(path, "utf-8");
+  const { frontmatter } = parseContextCapsuleDocument(content);
+  const createdAt = Date.parse(frontmatter.created_at);
+  if (Number.isNaN(createdAt)) return null;
+
+  return {
+    path,
+    content,
+    sha: hashText(content),
+    token: createCapsuleToken(frontmatter),
+    createdAt,
+  };
+}
+
+export async function findLatestContextCapsule(
+  directory = DEFAULT_CONTEXT_CAPSULE_DIRECTORY,
+): Promise<ContextCapsuleRef | null> {
+  let entries: string[];
+  try {
+    entries = await readdir(directory);
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") return null;
+    throw error;
+  }
+
+  const capsules = await Promise.all(
+    entries.filter((entry) => entry.endsWith(".md")).map((entry) => readCapsuleRef(join(directory, entry))),
+  );
+  const latest = capsules
+    .filter((capsule): capsule is ContextCapsuleRef & { readonly createdAt: number } => capsule !== null)
+    .sort((left, right) => right.createdAt - left.createdAt || left.path.localeCompare(right.path))[0];
+
+  if (!latest) return null;
+  const { createdAt: _createdAt, ...ref } = latest;
+  return ref;
+}

--- a/src/agents/context-capsule/types.ts
+++ b/src/agents/context-capsule/types.ts
@@ -1,0 +1,77 @@
+export const CAPSULE_STATUSES = ["none", "fresh", "partially-stale", "discarded", "skipped", "blocked"] as const;
+
+export type CapsuleStatus = (typeof CAPSULE_STATUSES)[number];
+export type CapsuleFreshnessStatus = "fresh" | "partially-stale" | "discarded";
+
+export interface ContextCapsuleFrontmatter {
+  readonly lifecycle_issue: number | null;
+  readonly branch: string;
+  readonly head_sha: string;
+  readonly worktree: string;
+  readonly created_at: string;
+  readonly source_files: readonly string[];
+  readonly source_hashes: Readonly<Record<string, string>>;
+}
+
+export interface ContextCapsuleSource {
+  readonly path: string;
+  readonly content: string;
+}
+
+export interface ContextCapsuleBuildInput {
+  readonly topic: string;
+  readonly lifecycleIssue: number | null;
+  readonly branch: string;
+  readonly headSha: string;
+  readonly worktree: string;
+  readonly sourceFiles: readonly ContextCapsuleSource[];
+  readonly confirmedFacts: readonly string[];
+  readonly createdAt?: Date;
+  readonly outputDir?: string;
+  readonly softWindowRatio?: number;
+}
+
+export interface BuiltContextCapsule {
+  readonly status: "fresh";
+  readonly path: string;
+  readonly sha: string;
+  readonly token: string;
+  readonly frontmatter: ContextCapsuleFrontmatter;
+  readonly body: string;
+  readonly document: string;
+  readonly warnings: readonly string[];
+}
+
+export interface BlockedContextCapsule {
+  readonly status: "blocked";
+  readonly reason: string;
+  readonly detail?: string;
+}
+
+export type BuildContextCapsuleResult = BuiltContextCapsule | BlockedContextCapsule;
+
+export interface ContextCapsuleRef {
+  readonly path: string;
+  readonly sha: string;
+  readonly token: string;
+  readonly content: string;
+}
+
+export interface ContextCapsuleFreshnessInput {
+  readonly expectedLifecycleIssue: number | null;
+  readonly branch: string;
+  readonly headSha: string;
+  readonly worktree: string;
+  readonly sourceHashes: Readonly<Record<string, string>>;
+  readonly frontmatter: ContextCapsuleFrontmatter;
+}
+
+export interface ContextCapsuleFreshnessResult {
+  readonly status: CapsuleFreshnessStatus;
+  readonly reasons: readonly string[];
+  readonly staleSourceFiles: readonly string[];
+}
+
+export function isCapsuleStatus(value: string): value is CapsuleStatus {
+  return (CAPSULE_STATUSES as readonly string[]).includes(value);
+}

--- a/src/agents/executor.ts
+++ b/src/agents/executor.ts
@@ -4,6 +4,7 @@ import { ATLAS_MENTAL_MODEL_PROTOCOL } from "@/agents/atlas-mental-model";
 import { DECISION_MINIMAL_RESPONSE_PROTOCOL } from "@/agents/decision-minimal-response";
 import { PROJECT_MEMORY_PROTOCOL } from "@/agents/project-memory-protocol";
 import { QUESTION_FIRST_DECISION_PROTOCOL } from "@/agents/question-first-decision";
+import { CONTEXT_CAPSULE_PROTOCOL } from "./context-capsule-protocol";
 
 export const executorAgent: AgentConfig = {
   description: "Executes plan with batch-first parallelism - groups independent tasks, spawns all in parallel",
@@ -173,10 +174,17 @@ When spawning, append to the implementer or reviewer prompt:
 </prompt-snippet>
 </contract-propagation>
 
+${CONTEXT_CAPSULE_PROTOCOL}
 ${ATLAS_MENTAL_MODEL_PROTOCOL}
 ${PROJECT_MEMORY_PROTOCOL}
 ${DECISION_MINIMAL_RESPONSE_PROTOCOL}
 ${QUESTION_FIRST_DECISION_PROTOCOL}
+
+<executor-context-capsule-note priority="critical">
+<rule>For every implementer/reviewer fan-out, keep capsule in front, context-brief after: inject the immutable <context-capsule> block at the user prompt top, then <spawn-meta>, then the per-task <context-brief>, then task-specific instructions.</rule>
+<rule><context-brief> remains mandatory for every implementer/reviewer spawn; the capsule is a shared cache-friendly prefix and never replaces the per-task confirmed-facts delta.</rule>
+<rule>capsule never replaces review policy: reviewer coverage, mandatory triggers, low-risk whitelist checks, and review skipped: low-risk whitelist reporting still follow <review-policy-execution>.</rule>
+</executor-context-capsule-note>
 
 <atlas-propagation priority="high">
 <rule>leaf agents (implementer-*, reviewer) do NOT have access to the atlas_lookup tool. They receive atlas excerpts only when you (executor) decide a task touches module boundaries, user-visible behaviour, decisions, or risks.</rule>

--- a/src/agents/knowledge-context-section.ts
+++ b/src/agents/knowledge-context-section.ts
@@ -20,10 +20,11 @@ export const KNOWLEDGE_CONTEXT_SECTION = `<section name="本次知识上下文">
 - **关系：** 一句话描述与本任务相关的 module / contract / decision 关系（可选；只在跨模块或跨决策时出现）。
 - **维护：** 列出本任务在 Atlas / Project Memory / Mindmodel 上的写入动作（最多 3-5 项；包括 atlas 节点更新、project_memory_promote 类型 + entity、delta 文件路径）。如果没有写入，写 "无"。
 - **传给子 agent：** 如果本任务通过 executor 派给子 agent，列出 context-brief 摘要长度 / 包含的 atlas 节点数 / Project Memory 条目数（用于审计父子协同）。
-本段结尾固定附两行状态：
+本段结尾固定附三行状态：
 \`Atlas status: <value>\`
 \`Project Memory status: <value>\`
-取值参见各自协议块的 status enum。
+\`Capsule status: <none|fresh|partially-stale|discarded|skipped:<reason>|blocked:<reason>>\`
+Atlas / Project Memory 取值参见各自协议块的 status enum；Capsule status 表示本任务是否读取、使用或丢弃 working-context capsule。
 </knowledge-context-section>
 </section>
 

--- a/src/agents/mindmodel/orchestrator.ts
+++ b/src/agents/mindmodel/orchestrator.ts
@@ -1,6 +1,8 @@
 // src/agents/mindmodel/orchestrator.ts
 import type { AgentConfig } from "@opencode-ai/sdk";
 
+import { CONTEXT_CAPSULE_PROTOCOL } from "@/agents/context-capsule-protocol";
+
 const PROMPT = `<environment>
 You are running as part of the "micode" OpenCode plugin.
 You are the ORCHESTRATOR for mindmodel v2 generation.
@@ -28,6 +30,12 @@ Phase 2 - Assembly:
 PARALLEL EXECUTION: spawn_agent accepts an ARRAY of agents that run in parallel via Promise.all.
 Pass ALL agents for a phase in ONE spawn_agent call to run them concurrently.
 </critical-rule>
+
+${CONTEXT_CAPSULE_PROTOCOL}
+
+<context-capsule-usage>
+For Phase 1 parallel analysis, create or reuse one Context Capsule from project entry/config/test discovery already known to this orchestrator and pass the same contextCapsule object to every Phase 1 worker. Phase 2 receives Phase 1 outputs as normal task-specific prompt content.
+</context-capsule-usage>
 
 <spawn_agent-api>
 spawn_agent takes an "agents" array parameter. Each element has: agent, prompt, description.

--- a/src/tools/spawn-agent-args.ts
+++ b/src/tools/spawn-agent-args.ts
@@ -3,11 +3,19 @@ import * as v from "valibot";
 
 import { normalizeSequence } from "@/tools/sequence";
 
+const ContextCapsuleSchema = v.object({
+  path: v.string(),
+  sha: v.string(),
+  token: v.string(),
+  content: v.string(),
+});
+
 export const AgentTaskSchema = v.object({
   agent: v.string(),
   prompt: v.string(),
   description: v.string(),
   model: v.optional(v.string()),
+  contextCapsule: v.optional(ContextCapsuleSchema),
 });
 
 export type AgentTask = v.InferOutput<typeof AgentTaskSchema>;

--- a/src/tools/spawn-agent/tool.ts
+++ b/src/tools/spawn-agent/tool.ts
@@ -1,6 +1,7 @@
 import type { PluginInput, ToolDefinition } from "@opencode-ai/plugin";
 import { type ToolContext, tool } from "@opencode-ai/plugin/tool";
 
+import { applyContextCapsulePrefix } from "@/agents/context-capsule/injector";
 import { dumpRawArgs, isDebugDumpEnabled } from "@/tools/diagnostics";
 import { sequenceSchema } from "@/tools/sequence";
 import { type AgentTask, normalizeSpawnAgentArgs } from "@/tools/spawn-agent-args";
@@ -166,11 +167,20 @@ If that condition is not met, abort this tool call and use Task instead.
 This is a transitional escape hatch and will be removed once Task supports a model parameter.`;
 
 const TASK_MODEL_DESCRIPTION = "Optional provider/model override for this spawned agent";
+const contextCapsuleSchema = tool.schema.object({
+  path: tool.schema.string(),
+  sha: tool.schema.string(),
+  token: tool.schema.string(),
+  content: tool.schema.string(),
+});
 const taskObjectSchema = tool.schema.object({
   agent: tool.schema.string().describe("Agent name to spawn"),
   prompt: tool.schema.string().describe("Full prompt/instructions for the agent"),
   description: tool.schema.string().describe("Short human-readable description"),
   model: tool.schema.string().optional().describe(TASK_MODEL_DESCRIPTION),
+  contextCapsule: contextCapsuleSchema
+    .optional()
+    .describe("Optional immutable context capsule prefix for the spawned user prompt"),
 });
 
 type AgentsSchema = ReturnType<typeof sequenceSchema>;
@@ -258,7 +268,10 @@ function buildPromptBody(
   task: AgentTask,
   model: ModelReference | null,
 ): { parts: { type: "text"; text: string }[]; agent: string; model?: ModelReference } {
-  const base = { parts: [{ type: "text" as const, text: task.prompt }], agent: task.agent };
+  const base = {
+    parts: [{ type: "text" as const, text: applyContextCapsulePrefix(task.prompt, task.contextCapsule) }],
+    agent: task.agent,
+  };
   return model ? { ...base, model } : base;
 }
 

--- a/tests/agents/atlas-initializer-context-capsule.test.ts
+++ b/tests/agents/atlas-initializer-context-capsule.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+
+import { atlasInitializerAgent } from "@/agents/atlas-initializer";
+import { CONTEXT_CAPSULE_PROTOCOL } from "@/agents/context-capsule-protocol";
+
+describe("atlas-initializer context capsule protocol", () => {
+  it("injects the canonical context capsule protocol before the phase plan", () => {
+    const prompt = atlasInitializerAgent.prompt;
+
+    expect(prompt).toContain(CONTEXT_CAPSULE_PROTOCOL);
+
+    const protocolIndex = prompt.indexOf(CONTEXT_CAPSULE_PROTOCOL);
+    const phasePlanIndex = prompt.indexOf("<phase-plan>");
+
+    expect(protocolIndex).toBeGreaterThan(-1);
+    expect(phasePlanIndex).toBeGreaterThan(-1);
+    expect(protocolIndex).toBeLessThan(phasePlanIndex);
+  });
+
+  it("keeps the capsule as hot-path context and not an atlas node", () => {
+    const prompt = atlasInitializerAgent.prompt;
+
+    expect(prompt).toContain("capsule is not an atlas node");
+    expect(prompt).toContain("same contextCapsule object");
+    expect(prompt).toContain("hot-path prompt prefix");
+  });
+
+  it("preserves normal atlas initializer write and reconcile flow", () => {
+    const prompt = atlasInitializerAgent.prompt;
+
+    expect(prompt).toContain('<phase name="4-reconcile"');
+    expect(prompt).toContain('<phase name="5-write"');
+    expect(prompt).toContain("Collect all worker output");
+    expect(prompt).toContain("Write all atlas/ files");
+    expect(prompt).toContain("Write 00-index.md last");
+  });
+});

--- a/tests/agents/context-capsule-drift-guard.test.ts
+++ b/tests/agents/context-capsule-drift-guard.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "bun:test";
+
+import { brainstormerAgent } from "@/agents/brainstormer";
+import { primaryAgent as commanderAgent } from "@/agents/commander";
+import { CONTEXT_CAPSULE_PROTOCOL } from "@/agents/context-capsule-protocol";
+import { executorAgent } from "@/agents/executor";
+
+const coordinatorPrompts = [
+  { name: "brainstormer", prompt: brainstormerAgent.prompt ?? "" },
+  { name: "commander", prompt: commanderAgent.prompt ?? "" },
+  { name: "executor", prompt: executorAgent.prompt ?? "" },
+];
+
+describe("context capsule shared protocol drift guard", () => {
+  it("injects the shared protocol into all coordinator prompts", () => {
+    for (const { name, prompt } of coordinatorPrompts) {
+      expect(prompt, `${name} prompt`).toContain(CONTEXT_CAPSULE_PROTOCOL);
+    }
+  });
+
+  it("preserves critical context capsule commitments", () => {
+    expect(CONTEXT_CAPSULE_PROTOCOL).toContain("user prompt TOP");
+    expect(CONTEXT_CAPSULE_PROTOCOL).toContain("Never inject capsule content into a system prompt");
+    expect(CONTEXT_CAPSULE_PROTOCOL).toContain("byte-identical");
+    expect(CONTEXT_CAPSULE_PROTOCOL).toContain("worker still must read its own target files");
+    expect(CONTEXT_CAPSULE_PROTOCOL).toContain("Capsule status");
+  });
+});
+
+describe("executor context capsule drift guard", () => {
+  const prompt = executorAgent.prompt ?? "";
+
+  it("injects the shared context capsule protocol", () => {
+    expect(prompt).toContain(CONTEXT_CAPSULE_PROTOCOL);
+  });
+
+  it("keeps capsule/context-brief/review-policy ordering phrases explicit", () => {
+    expect(prompt).toContain("<context-brief");
+    expect(prompt).toContain("capsule in front, context-brief after");
+    expect(prompt).toContain("<context-brief> remains mandatory");
+    expect(prompt).toContain("capsule never replaces review policy");
+  });
+});
+
+describe("commander context capsule drift guard", () => {
+  const prompt = commanderAgent.prompt ?? "";
+
+  it("injects the shared context capsule protocol", () => {
+    expect(prompt).toContain(CONTEXT_CAPSULE_PROTOCOL);
+  });
+
+  it("keeps same-lifecycle sequential reuse reporting explicit", () => {
+    expect(prompt).toContain("A→B");
+    expect(prompt).toContain("Capsule status");
+  });
+});
+
+describe("brainstormer context capsule drift guard", () => {
+  const prompt = brainstormerAgent.prompt ?? "";
+
+  it("injects the shared context capsule protocol", () => {
+    expect(prompt).toContain(CONTEXT_CAPSULE_PROTOCOL);
+  });
+
+  it("keeps capsule use before swarm and exploration fan-out", () => {
+    expect(prompt).toContain("Lens Swarm");
+    expect(prompt).toContain("critic/adversarial fan-out");
+    expect(prompt).toContain("exploration fan-out");
+    expect(prompt).toContain("A→B reuse");
+  });
+});

--- a/tests/agents/context-capsule-protocol.test.ts
+++ b/tests/agents/context-capsule-protocol.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test";
+
+import { CONTEXT_CAPSULE_PROTOCOL } from "@/agents/context-capsule-protocol";
+
+describe("Context Capsule protocol prompt fragment", () => {
+  it("exports the canonical immutable context capsule protocol", () => {
+    expect(
+      CONTEXT_CAPSULE_PROTOCOL,
+    ).toBe(`<context-capsule-protocol priority="critical" description="Immutable hot-path context prefix for subagent prompt cache reuse">
+<purpose>
+The Context Capsule is an immutable, short-lived hot-path artifact that carries already-read and already-confirmed facts into subagent user prompts. It is not durable knowledge, not Project Memory, not Atlas, not a replacement for context-brief, and not a live subagent session fork.
+</purpose>
+
+<injection-contract>
+- Inject the capsule into the user prompt TOP, before spawn-meta, before context-brief, before task-specific instructions.
+- Never inject capsule content into a system prompt or agent definition.
+- The exact <context-capsule>...</context-capsule> block for one fan-out MUST be byte-identical across every parallel worker so provider prompt cache can hit.
+- Task-specific deltas stay after the capsule. Existing <context-brief> remains the per-task executor/reviewer contract and must not be replaced by the capsule.
+</injection-contract>
+
+<reuse-boundary>
+- A→B reuse is allowed only for the same lifecycle issue, same branch, and same worktree.
+- Freshness preflight checks lifecycle issue, branch, HEAD SHA, worktree, and source file hashes before reuse.
+- Freshness result must be surfaced as Capsule status: <none|fresh|partially-stale|discarded|skipped:<reason>|blocked:<reason>>.
+</reuse-boundary>
+
+<safety-boundary>
+- Secret filtering is mandatory before writing any capsule file.
+- Do not write Authorization headers, tokens, private URLs, .env style values, raw logs, or credentials into a capsule.
+- Capsule is not durable knowledge: do not promote it to Project Memory, do not write it into Atlas, and do not treat it as a long-term source of truth.
+- The worker still must read its own target files before editing or reviewing. Capsule facts are a warm start, not the final evidence source.
+- Do not extend resume_subagent, do not fork live sessions, and do not change lifecycle recovery semantics for capsule reuse.
+</safety-boundary>
+</context-capsule-protocol>`);
+  });
+
+  it("contains all required contract concepts", () => {
+    expect(CONTEXT_CAPSULE_PROTOCOL).toContain("Context Capsule");
+    expect(CONTEXT_CAPSULE_PROTOCOL).toContain("immutable");
+    expect(CONTEXT_CAPSULE_PROTOCOL).toContain("user prompt TOP");
+    expect(CONTEXT_CAPSULE_PROTOCOL).toContain("Never inject capsule content into a system prompt");
+    expect(CONTEXT_CAPSULE_PROTOCOL).toContain("byte-identical");
+    expect(CONTEXT_CAPSULE_PROTOCOL).toContain("cache can hit");
+    expect(CONTEXT_CAPSULE_PROTOCOL).toContain("worker still must read its own target files");
+    expect(CONTEXT_CAPSULE_PROTOCOL).toContain("not durable knowledge");
+    expect(CONTEXT_CAPSULE_PROTOCOL).toContain("Project Memory");
+    expect(CONTEXT_CAPSULE_PROTOCOL).toContain("Atlas");
+    expect(CONTEXT_CAPSULE_PROTOCOL).toContain("context-brief");
+  });
+});

--- a/tests/agents/context-capsule/builder.test.ts
+++ b/tests/agents/context-capsule/builder.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildContextCapsule } from "@/agents/context-capsule/builder";
+import { hashText } from "@/agents/context-capsule/format";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "context-capsule-builder-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { force: true, recursive: true });
+});
+
+describe("context capsule builder", () => {
+  it("builds frontmatter, body, document, and immutable file artifact", () => {
+    const worktree = makeTempDir();
+    const outputDir = join(worktree, "capsules");
+    const result = buildContextCapsule({
+      topic: "Working Context Capsule / Subagent User Prompt Pro",
+      lifecycleIssue: 91,
+      branch: "issue-91-working-context-capsule",
+      headSha: "abc123",
+      worktree,
+      createdAt: new Date("2026-05-17T00:00:00.000Z"),
+      outputDir,
+      confirmedFacts: ["Batch 1 approved", "bun 1.3.13 available"],
+      sourceFiles: [
+        { path: "src/agents/executor.ts", content: "executor source" },
+        { path: "src/agents/planner.ts", content: "planner source" },
+      ],
+    });
+
+    expect(result.status).toBe("fresh");
+    if (result.status !== "fresh") throw new Error("expected fresh capsule");
+
+    expect(result.path).toStartWith(outputDir);
+    expect(result.path).toEndWith(".md");
+    expect(result.frontmatter).toEqual({
+      lifecycle_issue: 91,
+      branch: "issue-91-working-context-capsule",
+      head_sha: "abc123",
+      worktree,
+      created_at: "2026-05-17T00:00:00.000Z",
+      source_files: ["src/agents/executor.ts", "src/agents/planner.ts"],
+      source_hashes: {
+        "src/agents/executor.ts": hashText("executor source"),
+        "src/agents/planner.ts": hashText("planner source"),
+      },
+    });
+    expect(result.body).toContain("## Confirmed Facts");
+    expect(result.body).toContain("- Batch 1 approved");
+    expect(result.body).toContain("## Source Files");
+    expect(result.body).toContain(`- \`src/agents/executor.ts\` — sha256: ${hashText("executor source")}`);
+    expect(result.document).toContain("source_hashes:");
+    expect(result.sha).toBe(hashText(result.document));
+    expect(result.token).toHaveLength(16);
+    expect(result.warnings).toEqual([]);
+    expect(readFileSync(result.path, "utf8")).toBe(result.document);
+  });
+
+  it("uses the default shared context-capsules directory under the worktree", () => {
+    const worktree = makeTempDir();
+    const result = buildContextCapsule({
+      topic: "Default Output",
+      lifecycleIssue: null,
+      branch: "main",
+      headSha: "def456",
+      worktree,
+      createdAt: new Date("2026-05-17T00:00:00.000Z"),
+      confirmedFacts: [],
+      sourceFiles: [],
+    });
+
+    expect(result.status).toBe("fresh");
+    if (result.status !== "fresh") throw new Error("expected fresh capsule");
+    expect(result.path).toStartWith(join(worktree, "thoughts", "shared", "context-capsules"));
+  });
+
+  it("blocks writes when capsule input contains secrets", () => {
+    const worktree = makeTempDir();
+    const outputDir = join(worktree, "capsules");
+    const result = buildContextCapsule({
+      topic: "Secret Input",
+      lifecycleIssue: 91,
+      branch: "issue-91-working-context-capsule",
+      headSha: "abc123",
+      worktree,
+      createdAt: new Date("2026-05-17T00:00:00.000Z"),
+      outputDir,
+      confirmedFacts: ["Authorization: Bearer abc123"],
+      sourceFiles: [{ path: "src/agents/executor.ts", content: "executor source" }],
+    });
+
+    expect(result).toEqual({
+      status: "blocked",
+      reason: "secret_detected",
+      detail: "confirmedFacts: authorization_header",
+    });
+    expect(readdirSync(worktree)).toEqual([]);
+  });
+
+  it("warns about soft window ratio without blocking the write", () => {
+    const worktree = makeTempDir();
+    const result = buildContextCapsule({
+      topic: "Large Capsule",
+      lifecycleIssue: 91,
+      branch: "issue-91-working-context-capsule",
+      headSha: "abc123",
+      worktree,
+      createdAt: new Date("2026-05-17T00:00:00.000Z"),
+      softWindowRatio: 1.25,
+      confirmedFacts: ["Large but safe context"],
+      sourceFiles: [{ path: "src/agents/executor.ts", content: "executor source" }],
+    });
+
+    expect(result.status).toBe("fresh");
+    if (result.status !== "fresh") throw new Error("expected fresh capsule");
+    expect(result.warnings).toEqual(["soft_window_ratio: 1.25"]);
+    expect(readFileSync(result.path, "utf8")).toBe(result.document);
+  });
+});

--- a/tests/agents/context-capsule/format.test.ts
+++ b/tests/agents/context-capsule/format.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "bun:test";
+import {
+  createCapsuleToken,
+  hashText,
+  renderCapsuleDocument,
+  slugifyCapsuleTopic,
+} from "@/agents/context-capsule/format";
+import type { ContextCapsuleFrontmatter } from "@/agents/context-capsule/types";
+
+function frontmatter(overrides: Partial<ContextCapsuleFrontmatter> = {}): ContextCapsuleFrontmatter {
+  return {
+    lifecycle_issue: 91,
+    branch: "issue-91-working-context-capsule",
+    head_sha: "abc123",
+    worktree: "/root/CODE/issue-91-working-context-capsule",
+    created_at: "2026-05-17T00:00:00.000Z",
+    source_files: ["src/agents/executor.ts", "src/agents/planner.ts"],
+    source_hashes: {
+      "src/agents/executor.ts": "executor-hash",
+      "src/agents/planner.ts": "planner-hash",
+    },
+    ...overrides,
+  };
+}
+
+describe("context capsule formatting", () => {
+  it("hashes text with sha256", () => {
+    expect(hashText("context capsule")).toBe("2a0cc1dc1abe60fe526081192f8e2f7b1fad29dc66748f83eb2a197e4608c771");
+  });
+
+  it("slugifies topics with a stable fallback", () => {
+    expect(slugifyCapsuleTopic("Working Context Capsule / Subagent User Prompt Pro")).toBe(
+      "working-context-capsule-subagent-user-prompt-pro",
+    );
+    expect(slugifyCapsuleTopic("!!!")).toBe("context-capsule");
+    expect(slugifyCapsuleTopic("a".repeat(100))).toBe("a".repeat(80));
+  });
+
+  it("renders deterministic frontmatter with sorted arrays and records", () => {
+    const document = renderCapsuleDocument(
+      frontmatter({
+        branch: 'feature: "capsule"',
+        lifecycle_issue: null,
+        source_files: ["zeta.md", "alpha.md"],
+        source_hashes: { "zeta.md": "z-hash", "alpha.md": "a-hash" },
+      }),
+      "Body line\n",
+    );
+
+    expect(document).toBe(`---
+lifecycle_issue: null
+branch: "feature: \\"capsule\\""
+head_sha: "abc123"
+worktree: "/root/CODE/issue-91-working-context-capsule"
+created_at: "2026-05-17T00:00:00.000Z"
+source_files:
+  - "alpha.md"
+  - "zeta.md"
+source_hashes:
+  "alpha.md": "a-hash"
+  "zeta.md": "z-hash"
+---
+
+Body line
+`);
+  });
+
+  it("renders empty collections inline", () => {
+    const document = renderCapsuleDocument(frontmatter({ source_files: [], source_hashes: {} }), "Body");
+
+    expect(document).toContain("source_files:[]");
+    expect(document).toContain("source_hashes:{}");
+  });
+
+  it("creates a stable token independent of source hash order", () => {
+    const left = frontmatter({ source_hashes: { "b.ts": "b", "a.ts": "a" } });
+    const right = frontmatter({ source_hashes: { "a.ts": "a", "b.ts": "b" } });
+
+    expect(createCapsuleToken(left)).toBe(createCapsuleToken(right));
+    expect(createCapsuleToken(left)).toHaveLength(16);
+  });
+
+  it("changes the token when identity fields change", () => {
+    expect(createCapsuleToken(frontmatter({ head_sha: "abc123" }))).not.toBe(
+      createCapsuleToken(frontmatter({ head_sha: "def456" })),
+    );
+  });
+});

--- a/tests/agents/context-capsule/freshness.test.ts
+++ b/tests/agents/context-capsule/freshness.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "bun:test";
+import { evaluateContextCapsuleFreshness } from "@/agents/context-capsule/freshness";
+import type { ContextCapsuleFreshnessInput, ContextCapsuleFrontmatter } from "@/agents/context-capsule/types";
+
+function frontmatter(overrides: Partial<ContextCapsuleFrontmatter> = {}): ContextCapsuleFrontmatter {
+  return {
+    lifecycle_issue: 91,
+    branch: "issue-91-working-context-capsule",
+    head_sha: "abc123",
+    worktree: "/root/CODE/issue-91-working-context-capsule",
+    created_at: "2026-05-17T00:00:00.000Z",
+    source_files: ["src/agents/executor.ts", "src/agents/planner.ts"],
+    source_hashes: {
+      "src/agents/executor.ts": "executor-hash",
+      "src/agents/planner.ts": "planner-hash",
+    },
+    ...overrides,
+  };
+}
+
+function input(overrides: Partial<ContextCapsuleFreshnessInput> = {}): ContextCapsuleFreshnessInput {
+  return {
+    expectedLifecycleIssue: 91,
+    branch: "issue-91-working-context-capsule",
+    headSha: "abc123",
+    worktree: "/root/CODE/issue-91-working-context-capsule",
+    sourceHashes: {
+      "src/agents/executor.ts": "executor-hash",
+      "src/agents/planner.ts": "planner-hash",
+    },
+    frontmatter: frontmatter(),
+    ...overrides,
+  };
+}
+
+describe("context capsule freshness", () => {
+  it("returns fresh for an exact lifecycle, branch, worktree, HEAD, and source hash match", () => {
+    expect(evaluateContextCapsuleFreshness(input())).toEqual({
+      status: "fresh",
+      reasons: [],
+      staleSourceFiles: [],
+    });
+  });
+
+  it("returns partially-stale for HEAD and source hash drift with sorted stale source files", () => {
+    expect(
+      evaluateContextCapsuleFreshness(
+        input({
+          headSha: "def456",
+          sourceHashes: {
+            "src/agents/planner.ts": "new-planner-hash",
+            "src/agents/executor.ts": "new-executor-hash",
+          },
+        }),
+      ),
+    ).toEqual({
+      status: "partially-stale",
+      reasons: ["head_sha_changed", "source_hashes_changed"],
+      staleSourceFiles: ["src/agents/executor.ts", "src/agents/planner.ts"],
+    });
+  });
+
+  it("hard-discards when the lifecycle issue does not match", () => {
+    expect(evaluateContextCapsuleFreshness(input({ expectedLifecycleIssue: 92 }))).toEqual({
+      status: "discarded",
+      reasons: ["lifecycle_issue_mismatch"],
+      staleSourceFiles: [],
+    });
+  });
+
+  it("hard-discards when the branch does not match", () => {
+    expect(evaluateContextCapsuleFreshness(input({ branch: "issue-92-other-work" }))).toEqual({
+      status: "discarded",
+      reasons: ["branch_mismatch"],
+      staleSourceFiles: [],
+    });
+  });
+
+  it("hard-discards when the worktree does not match", () => {
+    expect(evaluateContextCapsuleFreshness(input({ worktree: "/root/CODE/issue-92-other-work" }))).toEqual({
+      status: "discarded",
+      reasons: ["worktree_mismatch"],
+      staleSourceFiles: [],
+    });
+  });
+});

--- a/tests/agents/context-capsule/index.test.ts
+++ b/tests/agents/context-capsule/index.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "bun:test";
+import * as capsule from "@/agents/context-capsule";
+
+describe("context capsule module index", () => {
+  it("exports the stable public API surface", () => {
+    expect(typeof capsule.CAPSULE_STATUSES).toBe("object");
+    expect(typeof capsule.slugifyCapsuleTopic).toBe("function");
+    expect(typeof capsule.assertCapsuleSafe).toBe("function");
+    expect(typeof capsule.applyContextCapsulePrefix).toBe("function");
+  });
+});

--- a/tests/agents/context-capsule/injector.test.ts
+++ b/tests/agents/context-capsule/injector.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "bun:test";
+import {
+  applyContextCapsulePrefix,
+  renderContextCapsulePrefix,
+  stripCapsuleFrontmatter,
+} from "@/agents/context-capsule/injector";
+import type { ContextCapsuleRef } from "@/agents/context-capsule/types";
+
+function capsule(overrides: Partial<ContextCapsuleRef> = {}): ContextCapsuleRef {
+  return {
+    path: "thoughts/context-capsules/issue-91.md",
+    sha: "abc123def456",
+    token: "fresh-token-001",
+    content: `---
+lifecycle_issue: 91
+branch: "issue-91-working-context-capsule"
+---
+
+## Confirmed Facts
+
+- Batch 1 approved.
+`,
+    ...overrides,
+  };
+}
+
+describe("context capsule injector", () => {
+  it("strips a leading YAML frontmatter block from capsule content", () => {
+    expect(stripCapsuleFrontmatter(capsule().content)).toBe(`## Confirmed Facts
+
+- Batch 1 approved.
+`);
+  });
+
+  it("leaves content without frontmatter unchanged", () => {
+    expect(stripCapsuleFrontmatter("## Body\n\nNo frontmatter.\n")).toBe("## Body\n\nNo frontmatter.\n");
+  });
+
+  it("renders the byte-stable context-capsule prefix with body and blank line", () => {
+    expect(
+      renderContextCapsulePrefix(capsule()),
+    ).toBe(`<context-capsule sha="abc123def456" fresh-token="fresh-token-001" path="thoughts/context-capsules/issue-91.md">
+## Confirmed Facts
+
+- Batch 1 approved.
+</context-capsule>
+
+`);
+  });
+
+  it("escapes XML-sensitive attribute values without changing body text", () => {
+    const prefix = renderContextCapsulePrefix(
+      capsule({ path: `capsules/issue-"91"-&-workers.md`, sha: `sha"&`, token: `tok<&>` }),
+    );
+
+    expect(prefix).toStartWith(
+      `<context-capsule sha="sha&quot;&amp;" fresh-token="tok&lt;&amp;&gt;" path="capsules/issue-&quot;91&quot;-&amp;-workers.md">`,
+    );
+  });
+
+  it("injects the capsule at the very top of the user prompt", () => {
+    const prompt = `<spawn-meta task-id="2.4" />\n<context-brief>facts</context-brief>\nImplement task.`;
+
+    expect(applyContextCapsulePrefix(prompt, capsule())).toBe(`${renderContextCapsulePrefix(capsule())}${prompt}`);
+  });
+
+  it("returns the original prompt when no capsule is available", () => {
+    const prompt = "Implement task.";
+
+    expect(applyContextCapsulePrefix(prompt, null)).toBe(prompt);
+    expect(applyContextCapsulePrefix(prompt, undefined)).toBe(prompt);
+  });
+});

--- a/tests/agents/context-capsule/redact.test.ts
+++ b/tests/agents/context-capsule/redact.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+import { assertCapsuleSafe, findCapsuleSecret } from "@/agents/context-capsule/redact";
+
+describe("context capsule redaction safety", () => {
+  it("allows clean capsule text", () => {
+    expect(assertCapsuleSafe("Implementation note: keep the summary under 500 tokens.")).toEqual({ ok: true });
+    expect(findCapsuleSecret("No credentials are present here.")).toBeNull();
+  });
+
+  it("flags Authorization headers", () => {
+    expect(findCapsuleSecret("Authorization: Bearer abc123")?.reason).toBe("authorization_header");
+  });
+
+  it("flags env-style secret assignments", () => {
+    expect(findCapsuleSecret("OPENAI_API_KEY=sk-example-value")?.reason).toBe("env_secret_assignment");
+  });
+
+  it("flags credential URLs", () => {
+    expect(findCapsuleSecret("https://user:pass@example.com/private")?.reason).toBe("credential_url");
+  });
+
+  it("flags raw log dumps", () => {
+    expect(findCapsuleSecret("[2026-05-17 01:02:03] DEBUG token exchange failed")?.reason).toBe("raw_log_dump");
+  });
+
+  it("flags generic secrets using shared detector", () => {
+    const result = assertCapsuleSafe('api_key: "Z9d0a8e3f5c7b2a1Z9d0a8e3"');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.match.reason).toBe("generic_secret");
+      expect(result.match.index).toBe(0);
+    }
+  });
+});

--- a/tests/agents/context-capsule/store.test.ts
+++ b/tests/agents/context-capsule/store.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createCapsuleToken, hashText, renderCapsuleDocument } from "@/agents/context-capsule/format";
+import { findLatestContextCapsule, parseContextCapsuleDocument } from "@/agents/context-capsule/store";
+import type { ContextCapsuleFrontmatter } from "@/agents/context-capsule/types";
+
+function frontmatter(overrides: Partial<ContextCapsuleFrontmatter> = {}): ContextCapsuleFrontmatter {
+  return {
+    lifecycle_issue: 91,
+    branch: "issue-91-working-context-capsule",
+    head_sha: "abc123",
+    worktree: "/root/CODE/issue-91-working-context-capsule",
+    created_at: "2026-05-17T00:00:00.000Z",
+    source_files: ["src/agents/executor.ts"],
+    source_hashes: { "src/agents/executor.ts": "executor-hash" },
+    ...overrides,
+  };
+}
+
+describe("context capsule store", () => {
+  it("parses frontmatter with yaml and preserves the markdown body", () => {
+    const document = renderCapsuleDocument(
+      frontmatter({
+        lifecycle_issue: null,
+        branch: "feature: capsule",
+        source_files: ["zeta.md", "alpha.md"],
+        source_hashes: { "zeta.md": "z-hash", "alpha.md": "a-hash" },
+      }),
+      "## Capsule\n\n- Keep this body intact.\n",
+    );
+
+    const parsed = parseContextCapsuleDocument(document);
+
+    expect(parsed.frontmatter).toEqual(
+      frontmatter({
+        lifecycle_issue: null,
+        branch: "feature: capsule",
+        source_files: ["alpha.md", "zeta.md"],
+        source_hashes: { "alpha.md": "a-hash", "zeta.md": "z-hash" },
+      }),
+    );
+    expect(parsed.body).toBe("## Capsule\n\n- Keep this body intact.\n");
+  });
+
+  it("returns null when the capsule directory is missing", async () => {
+    const root = mkdtempSync(join(tmpdir(), "capsule-store-missing-"));
+    try {
+      await expect(findLatestContextCapsule(join(root, "thoughts/shared/context-capsules"))).resolves.toBeNull();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("finds the latest capsule by created_at and returns path, content, sha, and token", async () => {
+    const root = mkdtempSync(join(tmpdir(), "capsule-store-"));
+    const directory = join(root, "thoughts/shared/context-capsules");
+    mkdirSync(directory, { recursive: true });
+    try {
+      const olderFrontmatter = frontmatter({ created_at: "2026-05-17T00:00:00.000Z", head_sha: "older" });
+      const newerFrontmatter = frontmatter({ created_at: "2026-05-17T00:05:00.000Z", head_sha: "newer" });
+      const older = renderCapsuleDocument(olderFrontmatter, "Older capsule");
+      const newer = renderCapsuleDocument(newerFrontmatter, "Newer capsule");
+
+      writeFileSync(join(directory, "2026-05-17T000000Z-older.md"), older);
+      writeFileSync(join(directory, "ignore.txt"), "not a capsule");
+      const newestPath = join(directory, "2026-05-17T000500Z-newer.md");
+      writeFileSync(newestPath, newer);
+
+      const latest = await findLatestContextCapsule(directory);
+
+      expect(latest).toEqual({
+        path: newestPath,
+        content: newer,
+        sha: hashText(newer),
+        token: createCapsuleToken(newerFrontmatter),
+      });
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+});

--- a/tests/agents/context-capsule/types.test.ts
+++ b/tests/agents/context-capsule/types.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "bun:test";
+import {
+  CAPSULE_STATUSES,
+  type CapsuleFreshnessStatus,
+  type ContextCapsuleFrontmatter,
+  isCapsuleStatus,
+} from "@/agents/context-capsule/types";
+
+describe("context capsule types", () => {
+  it("enumerates all user-visible capsule statuses", () => {
+    expect(CAPSULE_STATUSES).toEqual(["none", "fresh", "partially-stale", "discarded", "skipped", "blocked"]);
+    expect(isCapsuleStatus("fresh")).toBe(true);
+    expect(isCapsuleStatus("partially-stale")).toBe(true);
+    expect(isCapsuleStatus("blocked:secret")).toBe(false);
+    expect(isCapsuleStatus("unknown")).toBe(false);
+  });
+
+  it("allows the required frontmatter shape", () => {
+    const frontmatter: ContextCapsuleFrontmatter = {
+      lifecycle_issue: 91,
+      branch: "issue-91-working-context-capsule",
+      head_sha: "abc123",
+      worktree: "/root/CODE/issue-91-working-context-capsule",
+      created_at: "2026-05-17T00:00:00.000Z",
+      source_files: ["src/agents/executor.ts"],
+      source_hashes: { "src/agents/executor.ts": "hash" },
+    };
+
+    expect(frontmatter.lifecycle_issue).toBe(91);
+    const status: CapsuleFreshnessStatus = "fresh";
+    expect(status).toBe("fresh");
+  });
+});

--- a/tests/agents/effect-first-reporting.test.ts
+++ b/tests/agents/effect-first-reporting.test.ts
@@ -10,6 +10,7 @@ const AGENTS_MD = readFileSync(join(__dirname, "..", "..", "AGENTS.md"), "utf-8"
 
 const SECTION_LABELS = ["预期表现", "你可以怎么验收", "已知限制", "本次知识上下文", "实现记录"] as const;
 const EXCEPTION_KEYS = ["blocked", "failed-stop"] as const;
+const CAPSULE_STATUS_ENUM = "none|fresh|partially-stale|discarded|skipped:<reason>|blocked:<reason>";
 
 const PRIMARIES_WITH_BLOCK = [
   {
@@ -134,6 +135,14 @@ describe("effect-first-reporting prompt block", () => {
         expect(body).toContain("Atlas status:");
         expect(body).toContain("Project Memory status:");
       });
+
+      it(`${agent.name} knowledge-context subsection mentions Capsule status and allowed values`, () => {
+        const block = expandedEffectFirstBlock(agent.source);
+        expect(block).not.toBeNull();
+        const body = block ?? "";
+        expect(body).toContain("Capsule status:");
+        expect(body).toContain(CAPSULE_STATUS_ENUM);
+      });
     }
   });
 
@@ -195,6 +204,11 @@ describe("effect-first-reporting prompt block", () => {
     it("documents the 本次知识上下文 subsection", () => {
       expect(AGENTS_MD).toContain("本次知识上下文");
       expect(AGENTS_MD).toMatch(/Atlas status|Project Memory status/);
+    });
+
+    it("documents Capsule status and its enum in the 本次知识上下文 subsection", () => {
+      expect(AGENTS_MD).toContain("Capsule status:");
+      expect(AGENTS_MD).toContain(CAPSULE_STATUS_ENUM);
     });
 
     it("declares blocked and failed-stop exceptions", () => {

--- a/tests/agents/knowledge-context-section.test.ts
+++ b/tests/agents/knowledge-context-section.test.ts
@@ -27,4 +27,11 @@ describe("KNOWLEDGE_CONTEXT_SECTION", () => {
     expect(KNOWLEDGE_CONTEXT_SECTION).toContain("<knowledge-context-section");
     expect(KNOWLEDGE_CONTEXT_SECTION).toContain("</knowledge-context-section>");
   });
+
+  it("declares the working-context capsule status line and enum", () => {
+    expect(KNOWLEDGE_CONTEXT_SECTION).toContain("Capsule status:");
+    expect(KNOWLEDGE_CONTEXT_SECTION).toContain(
+      "<none|fresh|partially-stale|discarded|skipped:<reason>|blocked:<reason>>",
+    );
+  });
 });

--- a/tests/agents/leaf-no-knowledge-write.test.ts
+++ b/tests/agents/leaf-no-knowledge-write.test.ts
@@ -80,6 +80,12 @@ describe("executor injects context-brief protocol", () => {
     expect(executorPrompt).toMatch(/MUST (?:contain|include).*context-brief|context-brief.*MUST/i);
   });
 
+  it("describes Context Capsule as complementary to review policy and context-brief", () => {
+    expect(executorPrompt).toContain("Context Capsule");
+    expect(executorPrompt).toContain("capsule never replaces review policy");
+    expect(executorPrompt).toContain("<context-brief");
+  });
+
   it("shows available-subagents spawn examples with context brief immediately after spawn-meta", () => {
     const availableSubagents = executorPrompt.match(/<available-subagents>[\s\S]*?<\/available-subagents>/)?.[0] ?? "";
     expect(availableSubagents).not.toBe("");

--- a/tests/agents/mindmodel/orchestrator.test.ts
+++ b/tests/agents/mindmodel/orchestrator.test.ts
@@ -38,4 +38,12 @@ describe("mindmodel-orchestrator agent", () => {
     // Phase 2 - Assembly (includes example extraction)
     expect(prompt).toContain("mm-constraint-writer");
   });
+
+  it("should instruct Phase 1 fan-out to reuse one Context Capsule", () => {
+    const prompt = mindmodelOrchestratorAgent.prompt;
+
+    expect(prompt).toContain("Context Capsule");
+    expect(prompt).toContain("same contextCapsule object");
+    expect(prompt).toContain("Phase 1");
+  });
 });

--- a/tests/integration/context-capsule-ab-reuse.test.ts
+++ b/tests/integration/context-capsule-ab-reuse.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildContextCapsule,
+  evaluateContextCapsuleFreshness as checkContextCapsuleFreshness,
+  hashText,
+} from "@/agents/context-capsule";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "context-capsule-ab-reuse-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { force: true, recursive: true });
+});
+
+describe("context capsule A→B reuse integration", () => {
+  it("accepts a same-lifecycle capsule as fresh for a later subagent prompt", () => {
+    const worktree = makeTempDir();
+    const executorSource = "executor confirmed context";
+    const planSource = "plan confirmed context";
+    const capsule = buildContextCapsule({
+      topic: "A to B Reuse",
+      lifecycleIssue: 91,
+      branch: "issue-91-working-context-capsule",
+      headSha: "abc123",
+      worktree,
+      createdAt: new Date("2026-05-17T00:00:00.000Z"),
+      confirmedFacts: ["Batch 1 approved", "Batch 2 approved"],
+      sourceFiles: [
+        { path: "thoughts/shared/plans/issue-91-plan.md", content: planSource },
+        { path: "src/agents/executor.ts", content: executorSource },
+      ],
+    });
+
+    expect(capsule.status).toBe("fresh");
+    if (capsule.status !== "fresh") throw new Error("expected fresh capsule");
+
+    expect(
+      checkContextCapsuleFreshness({
+        expectedLifecycleIssue: 91,
+        branch: "issue-91-working-context-capsule",
+        headSha: "abc123",
+        worktree,
+        sourceHashes: {
+          "thoughts/shared/plans/issue-91-plan.md": hashText(planSource),
+          "src/agents/executor.ts": hashText(executorSource),
+        },
+        frontmatter: capsule.frontmatter,
+      }),
+    ).toEqual({
+      status: "fresh",
+      reasons: [],
+      staleSourceFiles: [],
+    });
+  });
+
+  it("marks same-lifecycle reuse as partially-stale when HEAD or source hashes drift", () => {
+    const worktree = makeTempDir();
+    const executorSource = "executor confirmed context";
+    const planSource = "plan confirmed context";
+    const capsule = buildContextCapsule({
+      topic: "Partially Stale Reuse",
+      lifecycleIssue: 91,
+      branch: "issue-91-working-context-capsule",
+      headSha: "abc123",
+      worktree,
+      createdAt: new Date("2026-05-17T00:00:00.000Z"),
+      confirmedFacts: ["Batch 3 approved"],
+      sourceFiles: [
+        { path: "thoughts/shared/plans/issue-91-plan.md", content: planSource },
+        { path: "src/agents/executor.ts", content: executorSource },
+      ],
+    });
+
+    expect(capsule.status).toBe("fresh");
+    if (capsule.status !== "fresh") throw new Error("expected fresh capsule");
+
+    expect(
+      checkContextCapsuleFreshness({
+        expectedLifecycleIssue: 91,
+        branch: "issue-91-working-context-capsule",
+        headSha: "def456",
+        worktree,
+        sourceHashes: {
+          "thoughts/shared/plans/issue-91-plan.md": hashText("plan confirmed context changed"),
+          "src/agents/executor.ts": hashText(executorSource),
+        },
+        frontmatter: capsule.frontmatter,
+      }),
+    ).toEqual({
+      status: "partially-stale",
+      reasons: ["head_sha_changed", "source_hashes_changed"],
+      staleSourceFiles: ["thoughts/shared/plans/issue-91-plan.md"],
+    });
+  });
+
+  it("discards A→B reuse when the branch no longer matches", () => {
+    const worktree = makeTempDir();
+    const capsule = buildContextCapsule({
+      topic: "Branch Mismatch Reuse",
+      lifecycleIssue: 91,
+      branch: "issue-91-working-context-capsule",
+      headSha: "abc123",
+      worktree,
+      createdAt: new Date("2026-05-17T00:00:00.000Z"),
+      confirmedFacts: ["Batch 4 started"],
+      sourceFiles: [{ path: "src/agents/executor.ts", content: "executor confirmed context" }],
+    });
+
+    expect(capsule.status).toBe("fresh");
+    if (capsule.status !== "fresh") throw new Error("expected fresh capsule");
+
+    expect(
+      checkContextCapsuleFreshness({
+        expectedLifecycleIssue: 91,
+        branch: "issue-92-other-work",
+        headSha: "abc123",
+        worktree,
+        sourceHashes: { "src/agents/executor.ts": hashText("executor confirmed context") },
+        frontmatter: capsule.frontmatter,
+      }),
+    ).toEqual({
+      status: "discarded",
+      reasons: ["branch_mismatch"],
+      staleSourceFiles: [],
+    });
+  });
+
+  it("blocks capsule creation before reuse when source context contains secrets", () => {
+    const worktree = makeTempDir();
+    const capsule = buildContextCapsule({
+      topic: "Secret Bearing Reuse",
+      lifecycleIssue: 91,
+      branch: "issue-91-working-context-capsule",
+      headSha: "abc123",
+      worktree,
+      createdAt: new Date("2026-05-17T00:00:00.000Z"),
+      confirmedFacts: ["Batch 4 started"],
+      sourceFiles: [{ path: "src/agents/executor.ts", content: "OPENAI_API_KEY=sk-test-1234567890abcdef" }],
+    });
+
+    expect(capsule).toEqual({
+      status: "blocked",
+      reason: "secret_detected",
+      detail: "sourceFiles:src/agents/executor.ts: env_secret_assignment",
+    });
+    expect(readdirSync(worktree)).toEqual([]);
+  });
+});

--- a/tests/integration/context-capsule-lens-swarm.test.ts
+++ b/tests/integration/context-capsule-lens-swarm.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import type { PluginInput } from "@opencode-ai/plugin";
+
+import type { ContextCapsuleRef } from "@/agents/context-capsule/types";
+import { createSpawnAgentTool } from "../../src/tools/spawn-agent";
+
+const SCOUT_COUNT = 5;
+
+const sharedContextCapsule: ContextCapsuleRef = {
+  path: "thoughts/shared/context-capsules/issue-91-lens-swarm.md",
+  sha: "capsule-sha-lens-swarm-001",
+  token: "fresh-token-lens-swarm-001",
+  content: `---
+lifecycle_issue: 91
+branch: issue-91-working-context-capsule-subagent-user-prompt-pro
+---
+
+## Shared Lens Swarm Capsule
+
+- All brainstorm-scout workers must receive this shared body byte-identically.
+- Frontmatter is storage metadata and must not enter spawned user prompts.
+`,
+};
+
+interface PromptCall {
+  readonly id: string;
+  readonly agent: string;
+  readonly text: string;
+}
+
+interface Recorder {
+  createCalls: number;
+  readonly promptCalls: PromptCall[];
+}
+
+interface FakeCtx {
+  readonly ctx: PluginInput;
+  readonly recorder: Recorder;
+}
+
+type ExecuteSignature = (raw: unknown, ctx: unknown) => Promise<string>;
+
+function buildSession(recorder: Recorder) {
+  return {
+    create: async () => {
+      recorder.createCalls += 1;
+      return { data: { id: `scout-session-${recorder.createCalls}` } };
+    },
+    prompt: async (input: {
+      readonly path: { readonly id: string };
+      readonly body: { readonly agent: string; readonly parts: readonly { readonly text: string }[] };
+    }) => {
+      recorder.promptCalls.push({
+        id: input.path.id,
+        agent: input.body.agent,
+        text: input.body.parts[0]?.text ?? "",
+      });
+    },
+    messages: async () => ({
+      data: [
+        {
+          info: { role: "assistant" as const },
+          parts: [{ type: "text", text: "Lens scout completed successfully." }],
+        },
+      ],
+    }),
+    delete: async () => {
+      /* noop */
+    },
+  };
+}
+
+function createFakeCtx(): FakeCtx {
+  const recorder: Recorder = { createCalls: 0, promptCalls: [] };
+  const ctx = {
+    directory: "/tmp/context-capsule-lens-swarm-test",
+    client: { session: buildSession(recorder) },
+  } as unknown as PluginInput;
+  return { ctx, recorder };
+}
+
+async function callExecute(toolDef: ReturnType<typeof createSpawnAgentTool>, args: unknown): Promise<string> {
+  const execute = toolDef.execute.bind(toolDef) as unknown as ExecuteSignature;
+  return execute(args, { sessionID: "parent-lens-swarm-session" });
+}
+
+function capsuleBlockBeforeSpawnMeta(promptText: string): string {
+  const spawnMetaIndex = promptText.indexOf("<spawn-meta");
+  expect(spawnMetaIndex).toBeGreaterThan(0);
+  return promptText.slice(0, spawnMetaIndex);
+}
+
+describe("context capsule lens swarm integration", () => {
+  let restoreConsoleLog: (() => void) | null = null;
+
+  beforeEach(() => {
+    const originalLog = console.log;
+    console.log = (_message?: unknown, ..._optional: unknown[]) => undefined;
+    restoreConsoleLog = () => {
+      console.log = originalLog;
+    };
+  });
+
+  afterEach(() => {
+    restoreConsoleLog?.();
+    restoreConsoleLog = null;
+  });
+
+  it("prefixes five parallel brainstorm-scout prompts with the same byte-identical capsule", async () => {
+    const fake = createFakeCtx();
+    const toolDef = createSpawnAgentTool(fake.ctx);
+    const agents = Array.from({ length: SCOUT_COUNT }, (_, index) => ({
+      agent: "brainstorm-scout",
+      description: `Lens scout ${index + 1}`,
+      prompt: `<spawn-meta task-id="lens-swarm-${index + 1}" />\nInvestigate lens ${index + 1}.`,
+      contextCapsule: sharedContextCapsule,
+    }));
+
+    const output = await callExecute(toolDef, { agents });
+
+    expect(output).toContain("| Description | Agent | Outcome | Elapsed | Output snippet |");
+    expect(fake.recorder.promptCalls).toHaveLength(SCOUT_COUNT);
+    expect(fake.recorder.promptCalls.every((call) => call.agent === "brainstorm-scout")).toBe(true);
+
+    const capsuleBlocks = fake.recorder.promptCalls.map((call) => capsuleBlockBeforeSpawnMeta(call.text));
+    const [firstBlock, ...remainingBlocks] = capsuleBlocks;
+
+    expect(firstBlock).toStartWith("<context-capsule");
+    for (const block of remainingBlocks) {
+      expect(block).toBe(firstBlock);
+    }
+
+    expect(firstBlock).toContain("## Shared Lens Swarm Capsule");
+    expect(firstBlock).toContain("- All brainstorm-scout workers must receive this shared body byte-identically.");
+    expect(firstBlock).toContain("- Frontmatter is storage metadata and must not enter spawned user prompts.");
+    expect(firstBlock).not.toContain("---");
+    expect(firstBlock).not.toContain("lifecycle_issue");
+    expect(firstBlock).not.toContain("branch:");
+  });
+});

--- a/tests/integration/spawn-agent-allsettled.test.ts
+++ b/tests/integration/spawn-agent-allsettled.test.ts
@@ -32,6 +32,25 @@ const SPAWN_SUCCESS_OUTPUT = "Spawn completed successfully.";
 const TASK_ERROR_OUTPUT = "TEST FAILED: focused integration test rejected the change.";
 const HARD_FAILURE_MESSAGE = "Spawned session crashed.";
 const RESUME_SUCCESS_OUTPUT = "Resume completed successfully.";
+const CONTEXT_CAPSULE_CONTENT = `---
+lifecycle_issue: 91
+---
+
+## Confirmed Facts
+
+- Capsule state should be launch-only.
+`;
+const CONTEXT_CAPSULE_TASK = {
+  ...TASK_ERROR_TASK,
+  prompt: "run the focused test with a capsule",
+  description: "Capsuled task error",
+  contextCapsule: {
+    path: "thoughts/shared/context-capsules/issue-91-working-context.md",
+    sha: "capsule-sha-allsettled",
+    token: "capsule-token-allsettled",
+    content: CONTEXT_CAPSULE_CONTENT,
+  },
+};
 
 interface PromptCall {
   readonly id: string;
@@ -129,5 +148,41 @@ describe("spawn_agent allSettled integration", () => {
     expect(secondSpawnOutput).not.toContain("Generation fence");
     expect(secondSpawnOutput).not.toContain("SessionID");
     expect(registry.get(TASK_ERROR_SESSION)).toBeNull();
+  });
+
+  it("does not preserve task_error sessions or capsule state when contextCapsule is present", async () => {
+    const registry = createPreservedRegistry({ maxResumes: MAX_RESUMES, ttlHours: TTL_HOURS });
+    const recorder: Recorder = { promptCalls: [], deleteCalls: [] };
+    const ctx = createCtx(recorder);
+    const seenCapsules: unknown[] = [];
+    const spawnTool = createSpawnAgentTool(ctx, {
+      registry,
+      executeAgentSession: async (_ctx, task) => {
+        seenCapsules.push(task.contextCapsule);
+        return { sessionId: TASK_ERROR_SESSION, output: TASK_ERROR_OUTPUT };
+      },
+    });
+
+    const spawnOutput = await callSpawnExecute(spawnTool, { agents: [CONTEXT_CAPSULE_TASK] });
+
+    expect(spawnOutput).toContain("**Outcome**: task_error");
+    expect(spawnOutput).not.toContain("SessionID");
+    expect(seenCapsules).toEqual([CONTEXT_CAPSULE_TASK.contextCapsule]);
+    expect(registry.size()).toBe(0);
+    expect(registry.get(TASK_ERROR_SESSION)).toBeNull();
+    expect(recorder.deleteCalls).toContain(TASK_ERROR_SESSION);
+
+    const resumeTool = createResumeSubagentTool(ctx, { registry });
+    const resumeOutput = await callResumeExecute(resumeTool, { session_id: TASK_ERROR_SESSION });
+
+    expect(resumeOutput).toContain("**Outcome**: hard_failure");
+    expect(resumeOutput).toContain("**SessionID**: -");
+    expect(resumeOutput).toContain("Session not preserved or expired.");
+    expect(resumeOutput).not.toContain("contextCapsule");
+    expect(resumeOutput).not.toContain("<context-capsule");
+    expect(resumeOutput).not.toContain(CONTEXT_CAPSULE_TASK.contextCapsule.token);
+    expect(resumeOutput).not.toContain(CONTEXT_CAPSULE_TASK.contextCapsule.sha);
+    expect(resumeOutput).not.toContain("Capsule state should be launch-only.");
+    expect(registry.size()).toBe(0);
   });
 });

--- a/tests/lifecycle/context-capsule-boundary.test.ts
+++ b/tests/lifecycle/context-capsule-boundary.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from "bun:test";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const CAPSULE_RUNTIME_DIRS = ["src/agents/context-capsule"] as const;
+const CAPSULE_RUNTIME_FILES = [
+  "src/agents/context-capsule-protocol.ts",
+  "src/tools/spawn-agent/tool.ts",
+  "src/tools/spawn-agent-args.ts",
+  "src/tools/resume-subagent.ts",
+] as const;
+const CAPSULE_MENTION_SCAN_DIRS = ["src/agents", "src/tools"] as const;
+const LIFECYCLE_BOUNDARY_SCAN_DIRS = ["src/lifecycle", "src/tools/lifecycle"] as const;
+const LIFECYCLE_BOUNDARY_EXTRA_FILES = ["src/tools/resume-subagent.ts"] as const;
+
+const CAPSULE_MENTION_PATTERN = /\b(?:contextCapsule|Context Capsule|context-capsule|context capsule)\b/iu;
+const PROJECT_MEMORY_PROMOTION_PATTERNS = [
+  /\bproject_memory_promote\s*\(/u,
+  /\bpromoteMarkdown\s*\(/u,
+  /from\s+["']@\/project-memory["']/u,
+] as const;
+const ATLAS_MUTATION_PATTERNS = [
+  /\batlasCompilerAgent\b/u,
+  /\b(?:write|update|maintain)Atlas\w*\b/u,
+  /\b(?:writeFileSync|appendFileSync)\s*\([^\n]*(?:["'`]atlas\/|\batlasPath\b)/u,
+] as const;
+const ATLAS_LOOKUP_PATTERN = /\batlas_lookup\b/u;
+const ATLAS_COMPILER_PATTERN = /\batlas-compiler\b/u;
+const RESUME_CAPSULE_SEMANTIC_PATTERNS = [
+  /\bcontextCapsule\b/u,
+  /\bContextCapsule\b/u,
+  /context-capsule/u,
+  /applyContextCapsulePrefix/u,
+] as const;
+const LIFECYCLE_CAPSULE_SEMANTIC_PATTERNS = [
+  /\bcontextCapsule\b/u,
+  /\bContext Capsule\b/u,
+  /<context-capsule\b/u,
+] as const;
+const NEARBY_LINE_WINDOW = 20;
+
+const walk = (dir: string, out: string[]): void => {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, out);
+    else if (entry.isFile() && entry.name.endsWith(".ts")) out.push(full);
+  }
+};
+
+const capsuleRuntimeFiles = (): readonly string[] => {
+  const files = [...CAPSULE_RUNTIME_FILES];
+  for (const dir of CAPSULE_RUNTIME_DIRS) walk(dir, files);
+  return [...new Set(files)].sort((left, right) => left.localeCompare(right));
+};
+
+const lifecycleBoundaryFiles = (): readonly string[] => {
+  const files: string[] = [];
+  for (const dir of LIFECYCLE_BOUNDARY_SCAN_DIRS) {
+    if (existsSync(dir)) walk(dir, files);
+  }
+  for (const file of LIFECYCLE_BOUNDARY_EXTRA_FILES) {
+    if (existsSync(file)) files.push(file);
+  }
+  return [...new Set(files)].sort((left, right) => left.localeCompare(right));
+};
+
+const sourceFilesWithCapsuleMentions = (): readonly string[] => {
+  const files: string[] = [];
+  for (const dir of CAPSULE_MENTION_SCAN_DIRS) walk(dir, files);
+  return files.filter((file) => CAPSULE_MENTION_PATTERN.test(readFileSync(file, "utf8")));
+};
+
+const findNearbyMatches = (
+  source: string,
+  forbiddenPatterns: readonly RegExp[],
+): Array<{
+  readonly capsuleLine: number;
+  readonly forbiddenLine: number;
+  readonly matched: string;
+  readonly text: string;
+}> => {
+  const lines = source.split("\n");
+  const capsuleLines = lines
+    .map((line, index) => ({ line, lineNumber: index + 1 }))
+    .filter(({ line }) => CAPSULE_MENTION_PATTERN.test(line))
+    .map(({ lineNumber }) => lineNumber);
+
+  const matches: Array<{
+    readonly capsuleLine: number;
+    readonly forbiddenLine: number;
+    readonly matched: string;
+    readonly text: string;
+  }> = [];
+  for (const capsuleLine of capsuleLines) {
+    const start = Math.max(1, capsuleLine - NEARBY_LINE_WINDOW);
+    const end = Math.min(lines.length, capsuleLine + NEARBY_LINE_WINDOW);
+    for (let lineNumber = start; lineNumber <= end; lineNumber += 1) {
+      const text = lines[lineNumber - 1] ?? "";
+      for (const pattern of forbiddenPatterns) {
+        if (pattern.test(text)) {
+          matches.push({ capsuleLine, forbiddenLine: lineNumber, matched: pattern.toString(), text: text.trim() });
+        }
+      }
+    }
+  }
+  return matches;
+};
+
+const findNearbyAtlasLookupWrites = (
+  source: string,
+): Array<{
+  readonly capsuleLine: number;
+  readonly forbiddenLine: number;
+  readonly matched: string;
+  readonly text: string;
+}> =>
+  findNearbyMatches(source, [ATLAS_LOOKUP_PATTERN]).filter(
+    ({ text }) => !/(?:Do not consult|do NOT have access to the) atlas_lookup/u.test(text),
+  );
+
+const findNearbyAtlasCompilerWrites = (
+  source: string,
+): Array<{
+  readonly capsuleLine: number;
+  readonly forbiddenLine: number;
+  readonly matched: string;
+  readonly text: string;
+}> =>
+  findNearbyMatches(source, [ATLAS_COMPILER_PATTERN]).filter(
+    ({ text }) => !/lifecycle 工具仍不 spawn atlas-compiler/u.test(text),
+  );
+
+describe("context capsule boundary", () => {
+  it("capsule runtime code does not promote Project Memory", () => {
+    const files = capsuleRuntimeFiles();
+    expect(files.length).toBeGreaterThan(0);
+
+    for (const file of files) {
+      const src = readFileSync(file, "utf8");
+      for (const pattern of PROJECT_MEMORY_PROMOTION_PATTERNS) {
+        expect({ file, matched: pattern.toString(), hit: pattern.test(src) }).toEqual({
+          file,
+          matched: pattern.toString(),
+          hit: false,
+        });
+      }
+    }
+  });
+
+  it("capsule runtime code does not update or maintain Atlas", () => {
+    const files = capsuleRuntimeFiles().filter((file) => file !== "src/agents/context-capsule-protocol.ts");
+    expect(files.length).toBeGreaterThan(0);
+
+    for (const file of files) {
+      const src = readFileSync(file, "utf8");
+      for (const pattern of ATLAS_MUTATION_PATTERNS) {
+        expect({ file, matched: pattern.toString(), hit: pattern.test(src) }).toEqual({
+          file,
+          matched: pattern.toString(),
+          hit: false,
+        });
+      }
+    }
+  });
+
+  it("capsule mentions are not adjacent to Project Memory or Atlas write semantics", () => {
+    const files = sourceFilesWithCapsuleMentions();
+    expect(files.length).toBeGreaterThan(0);
+
+    for (const file of files) {
+      const src = readFileSync(file, "utf8");
+      const nearbyProjectMemory = findNearbyMatches(src, PROJECT_MEMORY_PROMOTION_PATTERNS);
+      const nearbyAtlasMutation = findNearbyMatches(src, ATLAS_MUTATION_PATTERNS);
+      const nearbyAtlasLookupWrites = findNearbyAtlasLookupWrites(src);
+      const nearbyAtlasCompilerWrites = findNearbyAtlasCompilerWrites(src);
+      expect({
+        file,
+        nearbyProjectMemory,
+        nearbyAtlasMutation,
+        nearbyAtlasLookupWrites,
+        nearbyAtlasCompilerWrites,
+      }).toEqual({
+        file,
+        nearbyProjectMemory: [],
+        nearbyAtlasMutation: [],
+        nearbyAtlasLookupWrites: [],
+        nearbyAtlasCompilerWrites: [],
+      });
+    }
+  });
+
+  it("protocol explicitly keeps capsules out of durable knowledge and resume semantics", () => {
+    const src = readFileSync("src/agents/context-capsule-protocol.ts", "utf8");
+
+    expect(src).toContain("not Project Memory, not Atlas");
+    expect(src).toContain("do not promote it to Project Memory");
+    expect(src).toContain("do not write it into Atlas");
+    expect(src).toContain("Do not extend resume_subagent");
+    expect(src).toContain("do not fork live sessions");
+    expect(src).toContain("do not change lifecycle recovery semantics");
+  });
+
+  it("resume_subagent has no contextCapsule input or replay semantics", () => {
+    const src = readFileSync("src/tools/resume-subagent.ts", "utf8");
+
+    for (const pattern of RESUME_CAPSULE_SEMANTIC_PATTERNS) {
+      expect({ matched: pattern.toString(), hit: pattern.test(src) }).toEqual({
+        matched: pattern.toString(),
+        hit: false,
+      });
+    }
+    expect(src).toContain("session_id");
+    expect(src).toContain("hint");
+  });
+
+  it("lifecycle finish and resume sources have no capsule side effects", () => {
+    const files = lifecycleBoundaryFiles();
+    expect(files.length).toBeGreaterThan(0);
+
+    for (const file of files) {
+      const src = readFileSync(file, "utf8");
+      for (const pattern of LIFECYCLE_CAPSULE_SEMANTIC_PATTERNS) {
+        expect({ file, matched: pattern.toString(), hit: pattern.test(src) }).toEqual({
+          file,
+          matched: pattern.toString(),
+          hit: false,
+        });
+      }
+    }
+  });
+});

--- a/tests/tools/spawn-agent-args.test.ts
+++ b/tests/tools/spawn-agent-args.test.ts
@@ -86,6 +86,25 @@ describe("normalizeSpawnAgentArgs", () => {
         expect(outcome.tasks).toEqual([sampleTask, secondTask]);
       }
     });
+
+    it("preserves optional contextCapsule on tasks", () => {
+      const taskWithCapsule = {
+        ...sampleTask,
+        contextCapsule: {
+          path: "thoughts/shared/context-capsules/capsule.md",
+          sha: "abc123",
+          token: "capsule-token",
+          content: "# Working context\n\nDetails for the subagent.",
+        },
+      };
+
+      const outcome = normalizeSpawnAgentArgs({ agents: [taskWithCapsule] });
+
+      expect(outcome.ok).toBe(true);
+      if (outcome.ok) {
+        expect(outcome.tasks).toEqual([taskWithCapsule]);
+      }
+    });
   });
 
   describe("stringified accepted shapes", () => {
@@ -201,6 +220,24 @@ describe("normalizeSpawnAgentArgs", () => {
     it("rejects stringified task with wrong field type", () => {
       const outcome = normalizeSpawnAgentArgs({
         agents: JSON.stringify([{ agent: 1, prompt: "p", description: "d" }]),
+      });
+
+      expect(outcome).toEqual({ ok: false, message: INVALID_ARGS_MESSAGE });
+    });
+
+    it("rejects malformed contextCapsule", () => {
+      const outcome = normalizeSpawnAgentArgs({
+        agents: [
+          {
+            ...sampleTask,
+            contextCapsule: {
+              path: "thoughts/shared/context-capsules/capsule.md",
+              sha: "abc123",
+              token: "capsule-token",
+              content: 42,
+            },
+          },
+        ],
       });
 
       expect(outcome).toEqual({ ok: false, message: INVALID_ARGS_MESSAGE });

--- a/tests/tools/spawn-agent.test.ts
+++ b/tests/tools/spawn-agent.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import type { PluginInput } from "@opencode-ai/plugin";
 import { tool } from "@opencode-ai/plugin/tool";
 
+import type { ContextCapsuleRef } from "@/agents/context-capsule/types";
 import { buildArgsShape, createSpawnAgentTool } from "../../src/tools/spawn-agent";
 import { INVALID_ARGS_MESSAGE } from "../../src/tools/spawn-agent-args";
 
@@ -17,6 +18,21 @@ const taskB = {
   agent: "agent-b",
   prompt: "prompt b",
   description: "Task B description",
+};
+
+const contextCapsule: ContextCapsuleRef = {
+  path: "thoughts/shared/context-capsules/issue-91-working-context.md",
+  sha: "capsule-sha-001",
+  token: "fresh-token-001",
+  content: `---
+lifecycle_issue: 91
+branch: issue-91-working-context-capsule
+---
+
+## Confirmed Facts
+
+- Shared capsule body.
+`,
 };
 
 interface PromptCall {
@@ -199,6 +215,35 @@ describe("createSpawnAgentTool execute", () => {
 
       expect(output).toContain("Model override is not available: missing/model");
       expect(fake.recorder.createCalls).toBe(0);
+    });
+
+    it("prefixes each spawned user prompt with identical context capsule body only", async () => {
+      const promptA = `<spawn-meta task-id="3.2-a" />\nImplement prompt delta A.`;
+      const promptB = `<spawn-meta task-id="3.2-b" />\nImplement prompt delta B.`;
+
+      await callExecute(toolDef, {
+        agents: [
+          { ...taskA, prompt: promptA, contextCapsule },
+          { ...taskB, prompt: promptB, contextCapsule },
+        ],
+      });
+
+      const first = fake.recorder.promptCalls[0]?.text ?? "";
+      const second = fake.recorder.promptCalls[1]?.text ?? "";
+      const firstCapsule = first.slice(0, first.indexOf("</context-capsule>") + "</context-capsule>".length);
+      const secondCapsule = second.slice(0, second.indexOf("</context-capsule>") + "</context-capsule>".length);
+
+      expect(first).toStartWith("<context-capsule");
+      expect(second).toStartWith("<context-capsule");
+      expect(firstCapsule).toBe(secondCapsule);
+      expect(first).toContain(promptA);
+      expect(second).toContain(promptB);
+      expect(firstCapsule).toContain("## Confirmed Facts");
+      expect(firstCapsule).toContain("- Shared capsule body.");
+      expect(firstCapsule).not.toContain("---");
+      expect(firstCapsule).not.toContain("lifecycle_issue");
+      expect(secondCapsule).not.toContain("---");
+      expect(secondCapsule).not.toContain("lifecycle_issue");
     });
   });
 

--- a/thoughts/shared/designs/2026-05-17-working-context-capsule-design.md
+++ b/thoughts/shared/designs/2026-05-17-working-context-capsule-design.md
@@ -1,0 +1,228 @@
+---
+date: 2026-05-17
+topic: "Working Context Capsule for Subagent Prompt Cache Reuse"
+status: draft
+---
+
+## 承诺清单 / Commitments
+
+用户原话节选：
+- "多并发派Subagent的时候 ... 先准备一个Subagent 让他读取需要的文件作为关键上下文 然后直接fork他再二次分配开发任务 ... 利用了缓存机制 不需要重复读取文件了"
+- "完成a需求 然后想再做个b需求 做b需求的时候 agent会重新去读文件看上下文 我希望通过这个共享上下文的机制优化这个问题"
+- "直接注入了上下文 就类似fork一样"
+- "注入应该是按照用户提示词注入吧 不能注入系统提示词啥的"
+- "不需要大小限制吧"
+- "尽可能的多生效这个机制"
+
+sub-decision-identification 已确认决策（全 A 默认 + 删 size cap）：
+
+1. 存储位置：`thoughts/shared/context-capsules/YYYY-MM-DD-{topic}.md`（可 git diff / 可审计）
+2. 生成方：primary agent（brainstormer / commander / executor）在 spawn 前主动判断
+3. A→B 复用边界：同 lifecycle issue 内自动复用
+4. Freshness 校验：branch + HEAD SHA + 工作集文件 hash + lifecycle issue 都必须匹配
+5. 首版覆盖：S 级全做（Lens Swarm / executor batch / critic / 探索 fan-out / mm-orchestrator / atlas-initializer）+ B 级 A→B
+6. 大小硬上限：**删除**；只保留软约束「不塞无关内容」，上界由 context window 自然决定
+
+承诺条目（终态汇报「需求核对表」按此核对）：
+
+- 不做 live subagent session fork；改用不可变 user prompt 前缀注入
+- 不动 system prompt
+- byte-identical capsule 出现在每个并行 worker 的 user prompt 顶部（缓存命中硬要求）
+- A→B 复用仅在同 lifecycle issue 内生效
+- Freshness 失效不静默丢弃；终态可见复用状态
+- worker 仍必须读取自己的目标文件
+- 不破坏现有 context-brief / planner contract / reviewer policy / Atlas / PM
+- 不扩展 resume_subagent 承担 A→B 复用
+- 首版至少覆盖 Lens Swarm + executor batch + A→B 三个最小高频场景
+- secrets / raw logs / 凭据不得写入 capsule
+
+## Problem Statement
+
+当 primary agent 在短时间内派出多个 subagent，或用户连续完成需求 A 后做需求 B 时，每个 subagent 会独立调工具重读相同的关键文件、design、plan、contract、Atlas / Project Memory 条目。这造成三类浪费：
+
+- **重复 tool 调用时间**：每个 worker 自己 read / grep / lookup 一遍
+- **重复 token 成本**：相同事实被多次塞进模型输入
+- **未利用 provider prompt cache**：每个 worker prompt 前缀不同 → 缓存全部失败
+
+目标：把"已读、已确认的事实"做成不可变的 capsule，注入到所有 worker 的 user prompt 顶部，让 provider prompt cache 命中并消除重复读取。
+
+## Constraints
+
+- 仅注入 user prompt，绝不动 system prompt
+- byte-identical：同一 capsule 在每个并发 worker 的 user prompt 同一位置（顶部）出现，字节一致
+- 不引入 live subagent session fork 或全局 mutable cache
+- A→B 复用边界严格限定在同一 lifecycle issue + 同 branch + 同 worktree
+- Freshness 失败必须降级（部分复用 + stale 标注 或 discard），不得静默继续
+- 不破坏既有协议：context-brief / planner frozen contract / reviewer policy / Atlas / Project Memory / knowledge-context section
+- capsule 内容必须经过 secret 过滤
+- worker 必须仍然读取自己的目标文件作为最终事实源
+- 不扩展 resume_subagent 语义；resume 仍只为失败恢复
+
+## Approach
+
+**核心选择：immutable Context Capsule + user prompt 顶部稳定前缀注入**
+
+放弃方案及理由：
+
+1. **live subagent session fork**：拒绝 — 会污染任务身份 / resume 语义 / scope；现 runtime 不支持
+2. **resume_subagent 复用**：拒绝 — 改变安全/恢复原语，scope contamination
+3. **全局 semantic cache / daemonized context pool**：拒绝 — 隐式状态 + invalidation 复杂度过高
+4. **直接用 ledger 注入**：拒绝 — ledger 是会话纪要，颗粒度不对；capsule 是热路径事实摘要
+
+采用方案的关键性质：
+
+- capsule 一次生成、不可变
+- 注入到每个 worker user prompt 顶部、字节稳定 → provider prompt cache 命中
+- 同 lifecycle / branch / worktree 内可跨需求复用，附 freshness preflight
+- 失效降级而非静默丢弃，终态可见
+
+## Architecture
+
+三层缓存语义：
+
+| 层 | 生命周期 | 用途 |
+|---|---|---|
+| L1: 本轮 prompt prefix | 一次 spawn 批次 | 多个 worker 共享同一前缀，吃 provider cache |
+| L2: lifecycle-scoped capsule | 同 issue 内 | A→B 连续需求复用 |
+| L3: 长期知识引用 | 跨 lifecycle | 引用 Atlas 节点 / PM 条目 pointer，不重复内容 |
+
+落盘形态：
+
+- `thoughts/shared/context-capsules/YYYY-MM-DD-{topic}.md`
+- frontmatter 含 lifecycle_issue、branch、head_sha、worktree、created_at、source_files[]、source_hashes{}
+- body 是稳定文本 capsule（注入用的就是这一段）
+
+注入位置：
+
+```
+<context-capsule sha={capsule_sha} fresh-token={token}>
+... 不可变事实摘要 ...
+</context-capsule>
+
+<spawn-meta>...</spawn-meta>
+<context-brief>... task-specific delta ...</context-brief>
+
+任务：...
+```
+
+`<context-capsule>` 块出现在 user prompt 最顶部，跨所有并行 worker 字节相同。
+
+## Components
+
+**1. Capsule Builder（生成器）**
+- 位置：`src/agents/context-capsule/`（新模块）
+- 职责：把 primary agent 当前已读/已确认的事实压缩成 markdown 文本 + frontmatter；过滤 secret；计算 capsule_sha；记录 freshness token
+- 调用方：brainstormer / commander / executor 在准备 fan-out 前
+
+**2. Capsule Injector（注入器）**
+- 位置：`src/tools/spawn-agent/` 内增强（不另起工具）
+- 职责：spawn_agent / Task 在拼装子 agent prompt 时，把 capsule 文本插入 user prompt 顶部；保证字节稳定
+
+**3. Freshness Preflight（新鲜度校验）**
+- 位置：`src/agents/context-capsule/freshness.ts`（新模块）
+- 职责：复用前对比 branch / HEAD / source_hashes / lifecycle_issue；返回三档 `fresh | partially-stale | discarded`
+- 调用方：primary agent 在新需求开始时主动调用
+
+**4. Knowledge Context Section Hook**
+- 位置：扩展 `src/agents/knowledge-context-section.ts`（既有单源）
+- 职责：终态汇报"本次知识上下文"段加固定一行 `Capsule status: <none|fresh|partially-stale|discarded>` 与 capsule path
+
+**5. Drift Guard**
+- 位置：`tests/agents/context-capsule.test.ts`（新测试）
+- 职责：grep-based 保证 brainstormer / commander / executor prompt 中都引用同一份 capsule-injection 协议块
+
+**6. Sensitive Content Filter**
+- 位置：`src/agents/context-capsule/redact.ts`
+- 职责：阻断 `Authorization:` / token / private URL / `.env` 风格内容写入 capsule
+
+## Data Flow
+
+**Lens Swarm 场景（并发 5 scout）：**
+
+```
+brainstormer 决定派 5 scout
+  → 调 Capsule Builder：摘要提案上下文 + freshness token
+  → 写盘 thoughts/shared/context-capsules/...md
+  → 5 次 Task spawn，每次 user prompt 顶部注入同一 <context-capsule>
+  → provider prompt cache 命中首次写后的 4 次读取
+  → scout 各自只追加 lens-specific delta
+  → 5 个 scout 完成
+  → 终态汇报展示 Capsule status: fresh
+```
+
+**A→B 跨需求场景（同 lifecycle issue）：**
+
+```
+A 完成 → brainstormer / executor 在 lifecycle 终态时调 Capsule Builder
+  → 写盘 + frontmatter 记录 head_sha + source_hashes
+  → B 开始 → primary 调 Freshness Preflight
+    → fresh:           直接注入复用
+    → partially-stale: 注入 + 标注 stale 部分 + 局部重读
+    → discarded:       不复用，按新需求处理
+  → 终态汇报展示复用状态
+```
+
+**Executor batch 场景（多 implementer 并行）：**
+
+```
+executor 在 batch fan-out 前合并 plan + frozen contract + 行为承诺 → capsule
+  → 与 context-brief 并存：capsule 在前（稳定共享），context-brief 在后（per-task delta）
+  → 多 implementer 拿到字节相同的前缀
+  → cache 命中
+```
+
+## Error Handling
+
+- **capsule 生成失败**：跳过注入，按现有流程 spawn（degrade gracefully），终态汇报 `Capsule status: skipped: <reason>`
+- **freshness 校验失败（branch/worktree 变了）**：discarded，重新探索；不静默使用
+- **检测到 secret**：拒绝写盘，记录 `Capsule status: blocked: secret`，按现有流程 spawn
+- **provider 不支持 prompt cache**：注入仍然有效（减少 worker tool calls），只是省不到 cache 部分
+- **capsule 超过 context window 比例阈值（默认 30%）**：警告 + 让 primary agent 自决是否切片或跳过
+- **跨 lifecycle 误用**：Freshness Preflight 直接拒绝（lifecycle_issue 不匹配）
+
+## Testing Strategy
+
+- **单元测试**
+  - capsule builder：输入既有 atlas / PM / 文件摘要，输出 deterministic markdown
+  - redact filter：典型 secret pattern 必须被阻断
+  - freshness preflight：branch/HEAD/hash/issue 各失配组合返回正确档位
+- **协议注入测试**
+  - grep-based：brainstormer / commander / executor prompt 必须含 `<context-capsule>` 注入协议块
+  - byte-identical：同一批 spawn 多 worker，capsule 段字节一致
+- **集成测试**
+  - 模拟 Lens Swarm 5 scout：capsule 文件存在 + 5 个 spawn 调用 prompt 顶部一致
+  - 模拟 A→B：A 完成后 capsule 写盘，B 开始时 fresh/partial/discarded 三档分别走通
+- **回归保护**
+  - 现有 context-brief / planner / reviewer / leaf-no-knowledge-write 测试不破坏
+- **手动验收**（用户）
+  - 真实跑一次 Lens Swarm，观察终态 "Capsule status: fresh" + 5 scout 显著少调工具
+  - 完成需求 A 后再发需求 B（同 issue），观察 B 不重读文件
+
+## Open Questions
+
+- 是否在 octto 也复用 capsule（octto 多分支 brainstorm 场景）？首版**不做**，留 follow-up。
+- capsule 是否纳入 Project Memory？首版**不做**；capsule 是热路径短期 artifact，PM 是长期决策。
+- Lens Swarm 之外，pattern-finder / codebase-locator 默认要不要也吃 capsule？首版**做**（属 S 级探索 fan-out）。
+- atlas-initializer 多 worker 是否首版接入？首版**做**（属 S 级）。
+- 跨 worktree 同 issue（罕见）：默认拒绝复用，避免边界混乱；如需要后续单独评估。
+
+## Behavior
+
+**用户视角的可见行为承诺：**
+
+- 当 primary agent 派出 ≥2 个 subagent 时，自动生成并注入 capsule；用户在终态"本次知识上下文"段能看到 `Capsule status: fresh / partially-stale / discarded / skipped: <reason> / none`
+- 同一 lifecycle issue 内连续做需求 A、B 时，B 不再从零重读已确认的关键文件；终态可见复用了哪个 capsule
+- capsule 文件可在 `thoughts/shared/context-capsules/` 看到、git diff、人工 review
+- 切 branch / 切 worktree / 切 lifecycle 后，capsule 自动失效，不会污染新工作流
+- 不会把 token、Authorization、私有 URL、`.env` 内容写入 capsule
+- 不会改变现有 reviewer / planner / Atlas / PM / context-brief 行为
+- 现有 lifecycle 失败恢复 / resume_subagent 路径不受影响
+
+**验收方式：**
+
+- 跑一次 Lens Swarm（如对一个提案派 5 scout），打开 `thoughts/shared/context-capsules/` 看到对应文件；终态汇报含 `Capsule status: fresh`
+- 完成需求 A、立刻发需求 B（同 issue），B 的 subagent 不再 read 同一批文件；终态汇报指出复用了 A 的 capsule
+- 故意切 branch 后发 B，capsule 被 discarded，B 重新探索
+- 故意制造 secret 写入场景，capsule 被 blocked
+
+Atlas 关联：本次行为对应 atlas/20-behavior/ 中关于 subagent dispatch 与 context 复用的节点（若存在则更新，否则由 executor 在 batch 完成后由 atlas-worker-behavior 评估是否新增节点）。

--- a/thoughts/shared/plans/2026-05-17-working-context-capsule.md
+++ b/thoughts/shared/plans/2026-05-17-working-context-capsule.md
@@ -1,0 +1,1752 @@
+---
+date: 2026-05-17
+topic: "working-context-capsule"
+issue: 91
+scope: agents
+contract: none
+---
+
+# Working Context Capsule Implementation Plan
+
+**Goal:** Build an immutable, byte-identical Context Capsule user-prompt prefix for parallel subagents and same-lifecycle A→B reuse without changing system prompts, `resume_subagent`, planner contracts, reviewer policy, Atlas, or Project Memory boundaries.
+
+**Architecture:** Implement a small `src/agents/context-capsule/` runtime module for deterministic capsule input, secret blocking, frontmatter/hash generation, disk storage, and freshness preflight. Extend `spawn_agent` prompt assembly with an optional `contextCapsule` task field that writes/reuses the capsule once per fan-out and prefixes every worker user prompt with exactly the same bytes before existing per-task prompt content. Agent prompt changes use one shared `CONTEXT_CAPSULE_PROTOCOL` source so brainstormer / commander / executor stay drift-guarded while `context-brief` remains the task-specific delta after the capsule.
+
+**Design:** `thoughts/shared/designs/2026-05-17-working-context-capsule-design.md`
+
+**Contract:** none
+
+**按默认决定:** design 要求 no hard size limit 但 Error Handling 又提到 context-window awareness。实现默认采用 `softWindowRatio: 0.3` 只返回 warning，不阻断写入；理由是最不破坏用户确认的“无硬上限”，且可回滚为更严格策略。
+
+---
+
+## 行为承诺映射
+
+design.md `## Behavior` / `## 承诺清单 / Commitments` 段列出 17 条行为承诺：
+
+- 不做 live subagent session fork / 不扩展 `resume_subagent` → Batch 3 Task 3.2 只增强 `spawn_agent` prompt assembly；Batch 4 Task 4.7 测试 `resume_subagent` 路径无 capsule 参数和语义变化。
+- 不动 system prompt / capsule 注入 user prompt 顶部 → Batch 3 Task 3.2 在 `buildPromptBody` 前缀化 `task.prompt`；Batch 4 Task 4.2 用 5 worker 集成测试验证 prompt `startsWith("<context-capsule")`。
+- byte-identical capsule 出现在每个并行 worker 的 user prompt 顶部 → Batch 2 Task 2.4 的 injector helper 保证同一 `renderedPrefix` 复用；Batch 4 Task 4.2 验证 5 scout prompt capsule 段字节一致。
+- A→B 复用仅在同 lifecycle issue + same branch + same worktree 内生效 → Batch 2 Task 2.2 `freshness.ts` 与 Batch 2 Task 2.3 `store.ts` 实现边界；Batch 4 Task 4.3 覆盖 fresh / partially-stale / discarded 三档。
+- Freshness 失效不静默丢弃，终态可见复用状态 → Batch 2 Task 2.2 返回结构化状态；Batch 3 Task 3.3 在知识上下文单源增加 `Capsule status:`；Batch 4 Task 4.4 做 drift guard。
+- worker 仍必须读取自己的目标文件 → Batch 1 Task 1.5 `CONTEXT_CAPSULE_PROTOCOL` 明确 capsule 是共享已确认事实、不能替代 worker target-file read；Batch 4 Task 4.1 drift guard 检查该关键句。
+- 不破坏 context-brief / planner contract / reviewer policy / Atlas / PM → Batch 3 Task 3.6 只在 executor prompt 中规定 capsule 在 `<context-brief>` 前且 brief 保持 per-task delta；Batch 4 Task 4.5/4.6 回归 existing leaf/context-brief and knowledge-boundary tests。
+- secrets / raw logs / 凭据不得写入 capsule → Batch 1 Task 1.3 `redact.ts` 复用 `detectSecret` 并新增 Authorization/private URL/env 规则；Batch 2 Task 2.1 builder 遇 secret 返回 `blocked:secret` 不写盘；Batch 4 Task 4.3 覆盖 blocked。
+- 首版至少覆盖 Lens Swarm + executor batch + A→B → Batch 3 Task 3.4/3.5/3.6 primary prompts；Batch 3 Task 3.7/3.8 mm/atlas coordinator forwarding；Batch 4 Task 4.2/4.3 集成测试。
+- capsule 文件可在 `thoughts/shared/context-capsules/` 看到、git diff、人工 review → Batch 2 Task 2.1 builder 写入 frontmatter + body；Batch 2 Task 2.3 store 负责路径与 latest lookup。
+- 切 branch / worktree / lifecycle 后自动失效 → Batch 2 Task 2.2 freshness policy；Batch 4 Task 4.3 integration 覆盖 branch/worktree/issue mismatch discarded。
+- 不改变 lifecycle 失败恢复路径 → Batch 3 Task 3.2 不改 classifier / preserved registry / resume registry；Batch 4 Task 4.7 保持 allSettled/resume 回归。
+
+**未对应任何 task 的行为**：无。
+
+---
+
+## Review Policy
+
+- **Reviewer mandatory:** all tasks. Reasons: workflow-sensitive runtime prompt injection, `src/agents/**` prompt contracts, `src/tools/spawn-agent/**` runtime dispatch, secret filtering, cache/freshness behavior, context-brief preservation, and Behavior / Commitments coverage.
+- **Reviewer-skip eligible:** none. This feature has cache/retry/freshness/security/prompt-contract risk; no task meets the low-risk whitelist.
+- **Risk observations:** cache hit depends on byte-identical prefix (Tasks 2.4, 3.2, 4.2); stale capsule must not cross issue/branch/worktree (Tasks 2.2, 2.3, 4.3); capsule must not become durable knowledge or replace worker file reads (Tasks 1.5, 3.6, 4.1, 4.5).
+
+---
+
+## Dependency Graph
+
+```
+Batch 1 (parallel): 1.1, 1.2, 1.3, 1.4, 1.5 [foundation - no deps]
+Batch 2 (parallel): 2.1, 2.2, 2.3, 2.4 [core modules - depend on batch 1]
+Batch 3 (parallel): 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8 [runtime and prompt wiring - depend on batch 2 where imported]
+Batch 4 (parallel): 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7 [integration and drift guards - depend on batch 3]
+```
+
+---
+
+## Batch 1: Foundation (parallel - 5 implementers)
+
+All tasks in this batch have NO dependencies and run simultaneously.
+Tasks: 1.1, 1.2, 1.3, 1.4, 1.5
+
+### Task 1.1: Context Capsule Shared Types
+**File:** `src/agents/context-capsule/types.ts`
+**Test:** `tests/agents/context-capsule/types.test.ts`
+**Depends:** none
+**Domain:** general
+**Atlas-impact:** none
+**Behavior-impact:** Defines the immutable metadata/status contract used to report fresh / partially-stale / discarded / skipped / blocked states.
+**Review policy:** mandatory — shared runtime contract and status enum.
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import {
+  CAPSULE_STATUSES,
+  type CapsuleFreshnessStatus,
+  type ContextCapsuleFrontmatter,
+  isCapsuleStatus,
+} from "@/agents/context-capsule/types";
+
+describe("context capsule types", () => {
+  it("enumerates all user-visible capsule statuses", () => {
+    expect(CAPSULE_STATUSES).toEqual(["none", "fresh", "partially-stale", "discarded", "skipped", "blocked"]);
+    expect(isCapsuleStatus("fresh")).toBe(true);
+    expect(isCapsuleStatus("partially-stale")).toBe(true);
+    expect(isCapsuleStatus("blocked:secret")).toBe(false);
+    expect(isCapsuleStatus("unknown")).toBe(false);
+  });
+
+  it("allows the required frontmatter shape", () => {
+    const frontmatter: ContextCapsuleFrontmatter = {
+      lifecycle_issue: 91,
+      branch: "issue-91-working-context-capsule",
+      head_sha: "abc123",
+      worktree: "/root/CODE/issue-91-working-context-capsule",
+      created_at: "2026-05-17T00:00:00.000Z",
+      source_files: ["src/agents/executor.ts"],
+      source_hashes: { "src/agents/executor.ts": "hash" },
+    };
+
+    expect(frontmatter.lifecycle_issue).toBe(91);
+    const status: CapsuleFreshnessStatus = "fresh";
+    expect(status).toBe("fresh");
+  });
+});
+```
+
+```typescript
+export const CAPSULE_STATUSES = ["none", "fresh", "partially-stale", "discarded", "skipped", "blocked"] as const;
+
+export type CapsuleStatus = (typeof CAPSULE_STATUSES)[number];
+export type CapsuleFreshnessStatus = "fresh" | "partially-stale" | "discarded";
+
+export interface ContextCapsuleFrontmatter {
+  readonly lifecycle_issue: number | null;
+  readonly branch: string;
+  readonly head_sha: string;
+  readonly worktree: string;
+  readonly created_at: string;
+  readonly source_files: readonly string[];
+  readonly source_hashes: Readonly<Record<string, string>>;
+}
+
+export interface ContextCapsuleSource {
+  readonly path: string;
+  readonly content: string;
+}
+
+export interface ContextCapsuleBuildInput {
+  readonly topic: string;
+  readonly lifecycleIssue: number | null;
+  readonly branch: string;
+  readonly headSha: string;
+  readonly worktree: string;
+  readonly sourceFiles: readonly ContextCapsuleSource[];
+  readonly confirmedFacts: readonly string[];
+  readonly createdAt?: Date;
+  readonly outputDir?: string;
+  readonly softWindowRatio?: number;
+}
+
+export interface BuiltContextCapsule {
+  readonly status: "fresh";
+  readonly path: string;
+  readonly sha: string;
+  readonly token: string;
+  readonly frontmatter: ContextCapsuleFrontmatter;
+  readonly body: string;
+  readonly document: string;
+  readonly warnings: readonly string[];
+}
+
+export interface BlockedContextCapsule {
+  readonly status: "blocked";
+  readonly reason: string;
+  readonly detail?: string;
+}
+
+export type BuildContextCapsuleResult = BuiltContextCapsule | BlockedContextCapsule;
+
+export interface ContextCapsuleRef {
+  readonly path: string;
+  readonly sha: string;
+  readonly token: string;
+  readonly content: string;
+}
+
+export interface ContextCapsuleFreshnessInput {
+  readonly expectedLifecycleIssue: number | null;
+  readonly branch: string;
+  readonly headSha: string;
+  readonly worktree: string;
+  readonly sourceHashes: Readonly<Record<string, string>>;
+  readonly frontmatter: ContextCapsuleFrontmatter;
+}
+
+export interface ContextCapsuleFreshnessResult {
+  readonly status: CapsuleFreshnessStatus;
+  readonly reasons: readonly string[];
+  readonly staleSourceFiles: readonly string[];
+}
+
+export function isCapsuleStatus(value: string): value is CapsuleStatus {
+  return (CAPSULE_STATUSES as readonly string[]).includes(value);
+}
+```
+
+**Verify:** `bun test tests/agents/context-capsule/types.test.ts`
+**Commit:** `feat(agents): add context capsule shared types`
+
+### Task 1.2: Context Capsule Hashing and Formatting Helpers
+**File:** `src/agents/context-capsule/format.ts`
+**Test:** `tests/agents/context-capsule/format.test.ts`
+**Depends:** none
+**Domain:** general
+**Atlas-impact:** none
+**Behavior-impact:** Makes capsule markdown deterministic so parallel worker prefixes can be byte-identical.
+**Review policy:** mandatory — byte-identical cache hit depends on deterministic formatting.
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import { createCapsuleToken, hashText, renderCapsuleDocument, slugifyCapsuleTopic } from "@/agents/context-capsule/format";
+import type { ContextCapsuleFrontmatter } from "@/agents/context-capsule/types";
+
+const frontmatter: ContextCapsuleFrontmatter = {
+  lifecycle_issue: 91,
+  branch: "issue-91-working-context-capsule",
+  head_sha: "abc123",
+  worktree: "/root/CODE/issue-91",
+  created_at: "2026-05-17T00:00:00.000Z",
+  source_files: ["b.ts", "a.ts"],
+  source_hashes: { "b.ts": "hash-b", "a.ts": "hash-a" },
+};
+
+describe("context capsule format", () => {
+  it("slugifies topics for stable file names", () => {
+    expect(slugifyCapsuleTopic("Working Context Capsule for Subagent Prompt Cache Reuse")).toBe(
+      "working-context-capsule-for-subagent-prompt-cache-reuse",
+    );
+    expect(slugifyCapsuleTopic("---")).toBe("context-capsule");
+  });
+
+  it("hashes text with sha256", () => {
+    expect(hashText("abc")).toBe("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+  });
+
+  it("renders deterministic frontmatter and body", () => {
+    const first = renderCapsuleDocument(frontmatter, "body");
+    const second = renderCapsuleDocument(frontmatter, "body");
+    expect(first).toBe(second);
+    expect(first).toContain("source_files:\n  - a.ts\n  - b.ts");
+    expect(first).toContain("source_hashes:\n  a.ts: hash-a\n  b.ts: hash-b");
+    expect(first.endsWith("body\n")).toBe(true);
+  });
+
+  it("creates stable freshness tokens", () => {
+    expect(createCapsuleToken(frontmatter)).toBe(createCapsuleToken(frontmatter));
+  });
+});
+```
+
+```typescript
+import { createHash } from "node:crypto";
+import type { ContextCapsuleFrontmatter } from "./types";
+
+const FALLBACK_TOPIC = "context-capsule";
+
+export function hashText(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}
+
+export function slugifyCapsuleTopic(topic: string): string {
+  const slug = topic
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+  return slug.length > 0 ? slug : FALLBACK_TOPIC;
+}
+
+function quoteYaml(value: string): string {
+  return JSON.stringify(value);
+}
+
+function renderStringArray(values: readonly string[]): string {
+  if (values.length === 0) return "[]";
+  return `\n${[...values].sort().map((value) => `  - ${quoteYaml(value)}`).join("\n")}`;
+}
+
+function renderStringRecord(values: Readonly<Record<string, string>>): string {
+  const entries = Object.entries(values).sort(([left], [right]) => left.localeCompare(right));
+  if (entries.length === 0) return "{}";
+  return `\n${entries.map(([key, value]) => `  ${quoteYaml(key)}: ${quoteYaml(value)}`).join("\n")}`;
+}
+
+export function renderCapsuleDocument(frontmatter: ContextCapsuleFrontmatter, body: string): string {
+  const normalized: ContextCapsuleFrontmatter = {
+    ...frontmatter,
+    source_files: [...frontmatter.source_files].sort(),
+    source_hashes: Object.fromEntries(Object.entries(frontmatter.source_hashes).sort(([left], [right]) => left.localeCompare(right))),
+  };
+
+  return [
+    "---",
+    `lifecycle_issue: ${normalized.lifecycle_issue ?? "null"}`,
+    `branch: ${quoteYaml(normalized.branch)}`,
+    `head_sha: ${quoteYaml(normalized.head_sha)}`,
+    `worktree: ${quoteYaml(normalized.worktree)}`,
+    `created_at: ${quoteYaml(normalized.created_at)}`,
+    `source_files:${renderStringArray(normalized.source_files)}`,
+    `source_hashes:${renderStringRecord(normalized.source_hashes)}`,
+    "---",
+    "",
+    body.trimEnd(),
+    "",
+  ].join("\n");
+}
+
+export function createCapsuleToken(frontmatter: ContextCapsuleFrontmatter): string {
+  return hashText(
+    JSON.stringify({
+      lifecycle_issue: frontmatter.lifecycle_issue,
+      branch: frontmatter.branch,
+      head_sha: frontmatter.head_sha,
+      worktree: frontmatter.worktree,
+      source_hashes: Object.fromEntries(Object.entries(frontmatter.source_hashes).sort(([a], [b]) => a.localeCompare(b))),
+    }),
+  ).slice(0, 16);
+}
+```
+
+**Verify:** `bun test tests/agents/context-capsule/format.test.ts`
+**Commit:** `feat(agents): add context capsule formatting helpers`
+
+### Task 1.3: Context Capsule Secret Redaction Gate
+**File:** `src/agents/context-capsule/redact.ts`
+**Test:** `tests/agents/context-capsule/redact.test.ts`
+**Depends:** none
+**Domain:** general
+**Atlas-impact:** none
+**Behavior-impact:** Blocks token, Authorization, private URL, raw logs, and `.env` style content before capsule write.
+**Review policy:** mandatory — secrets/safety/security surface.
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import { assertCapsuleSafe, findCapsuleSecret } from "@/agents/context-capsule/redact";
+
+describe("context capsule redact gate", () => {
+  it("allows clean capsule text", () => {
+    expect(findCapsuleSecret("- Read src/agents/executor.ts and confirmed context-brief remains per-task.")).toBeNull();
+    expect(assertCapsuleSafe("clean")).toEqual({ ok: true });
+  });
+
+  it("blocks Authorization headers", () => {
+    expect(findCapsuleSecret("Authorization: Bearer abc")?.reason).toBe("authorization_header");
+  });
+
+  it("blocks .env style assignments", () => {
+    expect(findCapsuleSecret("OPENAI_API_KEY=sk-proj-abcdefghijklmnopqrstuvwxyz")?.reason).toBe("env_secret_assignment");
+  });
+
+  it("blocks private URLs with embedded credentials", () => {
+    expect(findCapsuleSecret("https://user:password@example.com/private")?.reason).toBe("credential_url");
+  });
+
+  it("blocks raw log dumps", () => {
+    expect(findCapsuleSecret("BEGIN RAW LOG\nAuthorization: Bearer abc\nEND RAW LOG")?.reason).toBe("raw_log_dump");
+  });
+
+  it("reuses generic secret detection", () => {
+    expect(findCapsuleSecret('token: "abcdefghijklmnopqrstuvwxyz012345"')?.reason).toBe("generic_secret");
+  });
+});
+```
+
+```typescript
+import { detectSecret, type SecretMatch } from "@/utils/secret-detect";
+
+export interface CapsuleSecretMatch extends SecretMatch {
+  readonly reason: string;
+}
+
+export type CapsuleSafetyResult = { readonly ok: true } | { readonly ok: false; readonly match: CapsuleSecretMatch };
+
+const EXTRA_PATTERNS: ReadonlyArray<{ readonly reason: string; readonly regex: RegExp }> = [
+  { reason: "authorization_header", regex: /^\s*Authorization\s*:\s*\S+/im },
+  { reason: "env_secret_assignment", regex: /^\s*[A-Z0-9_]*(?:API_KEY|TOKEN|SECRET|PASSWORD|PRIVATE_URL)[A-Z0-9_]*\s*=\s*\S+/im },
+  { reason: "credential_url", regex: /https?:\/\/[^\s/@:]+:[^\s/@]+@[^\s]+/i },
+  { reason: "raw_log_dump", regex: /BEGIN RAW LOG|END RAW LOG|^\[[0-9:. -]+\]\s+(?:DEBUG|TRACE|ERROR)/im },
+];
+
+export function findCapsuleSecret(text: string): CapsuleSecretMatch | null {
+  for (const { reason, regex } of EXTRA_PATTERNS) {
+    const match = regex.exec(text);
+    if (match) return { reason, index: match.index };
+  }
+  const generic = detectSecret(text);
+  return generic ? { reason: generic.reason, index: generic.index } : null;
+}
+
+export function assertCapsuleSafe(text: string): CapsuleSafetyResult {
+  const match = findCapsuleSecret(text);
+  return match ? { ok: false, match } : { ok: true };
+}
+```
+
+**Verify:** `bun test tests/agents/context-capsule/redact.test.ts`
+**Commit:** `feat(agents): block secrets in context capsules`
+
+### Task 1.4: Context Capsule Module Index
+**File:** `src/agents/context-capsule/index.ts`
+**Test:** `tests/agents/context-capsule/index.test.ts`
+**Depends:** none
+**Domain:** general
+**Atlas-impact:** none
+**Behavior-impact:** Provides one import surface for builder, freshness, store, injector, and prompt protocol without coupling callers to internal files.
+**Review policy:** mandatory — runtime module export contract.
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import * as capsule from "@/agents/context-capsule";
+
+describe("context capsule module index", () => {
+  it("exports the stable public API surface", () => {
+    expect(typeof capsule.CAPSULE_STATUSES).toBe("object");
+    expect(typeof capsule.slugifyCapsuleTopic).toBe("function");
+    expect(typeof capsule.assertCapsuleSafe).toBe("function");
+  });
+});
+```
+
+```typescript
+export * from "./types";
+export * from "./format";
+export * from "./redact";
+```
+
+**Verify:** `bun test tests/agents/context-capsule/index.test.ts`
+**Commit:** `feat(agents): expose context capsule module API`
+
+### Task 1.5: Context Capsule Prompt Protocol Source
+**File:** `src/agents/context-capsule-protocol.ts`
+**Test:** `tests/agents/context-capsule-protocol.test.ts`
+**Depends:** none
+**Domain:** general
+**Atlas-impact:** layer-update
+**Behavior-impact:** Establishes the single source prompt block requiring user-prompt top injection, byte identity, worker target-file reads, and Atlas/PM boundary preservation.
+**Review policy:** mandatory — agent prompt contract and Behavior / Commitments surface.
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import { CONTEXT_CAPSULE_PROTOCOL } from "@/agents/context-capsule-protocol";
+
+describe("CONTEXT_CAPSULE_PROTOCOL", () => {
+  it("defines immutable user-prompt top injection", () => {
+    expect(CONTEXT_CAPSULE_PROTOCOL).toContain("immutable Context Capsule");
+    expect(CONTEXT_CAPSULE_PROTOCOL).toContain("user prompt TOP");
+    expect(CONTEXT_CAPSULE_PROTOCOL).toContain("never system prompt");
+  });
+
+  it("requires byte-identical parallel worker prefixes", () => {
+    expect(CONTEXT_CAPSULE_PROTOCOL).toContain("byte-identical");
+    expect(CONTEXT_CAPSULE_PROTOCOL).toContain("cache hit");
+  });
+
+  it("preserves worker verification and knowledge boundaries", () => {
+    expect(CONTEXT_CAPSULE_PROTOCOL).toContain("worker still must read its own target files");
+    expect(CONTEXT_CAPSULE_PROTOCOL).toContain("not durable knowledge");
+    expect(CONTEXT_CAPSULE_PROTOCOL).toContain("Project Memory");
+    expect(CONTEXT_CAPSULE_PROTOCOL).toContain("Atlas");
+    expect(CONTEXT_CAPSULE_PROTOCOL).toContain("context-brief");
+  });
+});
+```
+
+```typescript
+export const CONTEXT_CAPSULE_PROTOCOL = `<context-capsule-protocol priority="critical" description="Immutable hot-path context prefix for subagent prompt cache reuse">
+<purpose>
+The Context Capsule is an immutable, short-lived hot-path artifact that carries already-read and already-confirmed facts into subagent user prompts. It is not durable knowledge, not Project Memory, not Atlas, not a replacement for context-brief, and not a live subagent session fork.
+</purpose>
+
+<injection-contract>
+- Inject the capsule into the user prompt TOP, before spawn-meta, before context-brief, before task-specific instructions.
+- Never inject capsule content into a system prompt or agent definition.
+- The exact <context-capsule>...</context-capsule> block for one fan-out MUST be byte-identical across every parallel worker so provider prompt cache can hit.
+- Task-specific deltas stay after the capsule. Existing <context-brief> remains the per-task executor/reviewer contract and must not be replaced by the capsule.
+</injection-contract>
+
+<reuse-boundary>
+- A→B reuse is allowed only for the same lifecycle issue, same branch, and same worktree.
+- Freshness preflight checks lifecycle issue, branch, HEAD SHA, worktree, and source file hashes before reuse.
+- Freshness result must be surfaced as Capsule status: <none|fresh|partially-stale|discarded|skipped:<reason>|blocked:<reason>>.
+</reuse-boundary>
+
+<safety-boundary>
+- Secret filtering is mandatory before writing any capsule file.
+- Do not write Authorization headers, tokens, private URLs, .env style values, raw logs, or credentials into a capsule.
+- Capsule is not durable knowledge: do not promote it to Project Memory, do not write it into Atlas, and do not treat it as a long-term source of truth.
+- The worker still must read its own target files before editing or reviewing. Capsule facts are a warm start, not the final evidence source.
+- Do not extend resume_subagent, do not fork live sessions, and do not change lifecycle recovery semantics for capsule reuse.
+</safety-boundary>
+</context-capsule-protocol>`;
+```
+
+**Verify:** `bun test tests/agents/context-capsule-protocol.test.ts`
+**Commit:** `feat(agents): add context capsule prompt protocol`
+
+---
+
+## Batch 2: Core Modules (parallel - 4 implementers)
+
+All tasks in this batch depend on Batch 1 completing.
+Tasks: 2.1, 2.2, 2.3, 2.4
+
+### Task 2.1: Context Capsule Builder
+**File:** `src/agents/context-capsule/builder.ts`
+**Test:** `tests/agents/context-capsule/builder.test.ts`
+**Depends:** 1.1, 1.2, 1.3
+**Domain:** general
+**Atlas-impact:** none
+**Behavior-impact:** Writes immutable capsule files under `thoughts/shared/context-capsules/` with required frontmatter and blocks writes when secrets are detected.
+**Review policy:** mandatory — file write, secret gate, deterministic cache artifact.
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildContextCapsule } from "@/agents/context-capsule/builder";
+
+const baseInput = {
+  topic: "Working Context Capsule",
+  lifecycleIssue: 91,
+  branch: "issue-91-working-context-capsule",
+  headSha: "abc123",
+  worktree: "/root/CODE/issue-91-working-context-capsule",
+  sourceFiles: [{ path: "src/agents/executor.ts", content: "executor prompt context" }],
+  confirmedFacts: ["context-brief remains task specific", "capsule injects into user prompt top"],
+  createdAt: new Date("2026-05-17T00:00:00.000Z"),
+};
+
+describe("buildContextCapsule", () => {
+  it("writes deterministic frontmatter and body", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "capsule-builder-"));
+    const result = await buildContextCapsule({ ...baseInput, outputDir });
+
+    expect(result.status).toBe("fresh");
+    if (result.status !== "fresh") throw new Error("expected fresh capsule");
+    expect(result.path).toContain("2026-05-17-working-context-capsule.md");
+    expect(result.frontmatter.lifecycle_issue).toBe(91);
+    expect(result.frontmatter.source_files).toEqual(["src/agents/executor.ts"]);
+    expect(result.body).toContain("context-brief remains task specific");
+    expect(result.document).toBe(readFileSync(result.path, "utf-8"));
+    expect(result.sha).toHaveLength(64);
+  });
+
+  it("blocks secret-bearing capsule content before write", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "capsule-builder-secret-"));
+    const result = await buildContextCapsule({
+      ...baseInput,
+      outputDir,
+      confirmedFacts: ["Authorization: Bearer abc"],
+    });
+
+    expect(result.status).toBe("blocked");
+    if (result.status !== "blocked") throw new Error("expected blocked capsule");
+    expect(result.reason).toBe("secret");
+  });
+
+  it("returns warnings instead of enforcing a hard size limit", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "capsule-builder-large-"));
+    const result = await buildContextCapsule({
+      ...baseInput,
+      outputDir,
+      confirmedFacts: ["x".repeat(4000)],
+      softWindowRatio: 0.0001,
+    });
+
+    expect(result.status).toBe("fresh");
+    if (result.status !== "fresh") throw new Error("expected fresh capsule");
+    expect(result.warnings.join("\n")).toContain("soft window ratio");
+  });
+});
+```
+
+```typescript
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { createCapsuleToken, hashText, renderCapsuleDocument, slugifyCapsuleTopic } from "./format";
+import { assertCapsuleSafe } from "./redact";
+import type { BuildContextCapsuleResult, ContextCapsuleBuildInput, ContextCapsuleFrontmatter } from "./types";
+
+const DEFAULT_CONTEXT_CAPSULE_DIR = join("thoughts", "shared", "context-capsules");
+const DEFAULT_SOFT_WINDOW_RATIO = 0.3;
+const SOFT_WINDOW_REFERENCE_CHARS = 120_000;
+
+function formatDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function buildBody(input: ContextCapsuleBuildInput): string {
+  const facts = input.confirmedFacts.map((fact) => `- ${fact.trim()}`).join("\n");
+  const sources = input.sourceFiles.map((source) => `- ${source.path}`).sort().join("\n");
+  return [
+    `<context-capsule-source topic="${input.topic}">`,
+    "## Confirmed Facts",
+    facts || "- No confirmed facts provided.",
+    "",
+    "## Source Files",
+    sources || "- No source files provided.",
+    "</context-capsule-source>",
+  ].join("\n");
+}
+
+function buildFrontmatter(input: ContextCapsuleBuildInput, createdAt: Date): ContextCapsuleFrontmatter {
+  const source_hashes = Object.fromEntries(
+    input.sourceFiles.map((source) => [source.path, hashText(source.content)]).sort(([left], [right]) => left.localeCompare(right)),
+  );
+  return {
+    lifecycle_issue: input.lifecycleIssue,
+    branch: input.branch,
+    head_sha: input.headSha,
+    worktree: input.worktree,
+    created_at: createdAt.toISOString(),
+    source_files: Object.keys(source_hashes),
+    source_hashes,
+  };
+}
+
+function sizeWarnings(document: string, softWindowRatio: number): readonly string[] {
+  const ratio = document.length / SOFT_WINDOW_REFERENCE_CHARS;
+  if (ratio <= softWindowRatio) return [];
+  return [`capsule exceeds soft window ratio ${softWindowRatio}; no hard size limit enforced`];
+}
+
+export async function buildContextCapsule(input: ContextCapsuleBuildInput): Promise<BuildContextCapsuleResult> {
+  const createdAt = input.createdAt ?? new Date();
+  const frontmatter = buildFrontmatter(input, createdAt);
+  const body = buildBody(input);
+  const document = renderCapsuleDocument(frontmatter, body);
+  const safety = assertCapsuleSafe(document);
+  if (!safety.ok) {
+    return { status: "blocked", reason: "secret", detail: safety.match.reason };
+  }
+
+  const outputDir = input.outputDir ?? DEFAULT_CONTEXT_CAPSULE_DIR;
+  mkdirSync(outputDir, { recursive: true });
+  const fileName = `${formatDate(createdAt)}-${slugifyCapsuleTopic(input.topic)}.md`;
+  const path = join(outputDir, fileName);
+  writeFileSync(path, document, "utf-8");
+
+  return {
+    status: "fresh",
+    path,
+    sha: hashText(document),
+    token: createCapsuleToken(frontmatter),
+    frontmatter,
+    body,
+    document,
+    warnings: sizeWarnings(document, input.softWindowRatio ?? DEFAULT_SOFT_WINDOW_RATIO),
+  };
+}
+```
+
+**Verify:** `bun test tests/agents/context-capsule/builder.test.ts`
+**Commit:** `feat(agents): build immutable context capsules`
+
+### Task 2.2: Context Capsule Freshness Preflight
+**File:** `src/agents/context-capsule/freshness.ts`
+**Test:** `tests/agents/context-capsule/freshness.test.ts`
+**Depends:** 1.1
+**Domain:** general
+**Atlas-impact:** none
+**Behavior-impact:** Enforces same lifecycle issue + branch + worktree boundary and returns fresh / partially-stale / discarded without silent reuse.
+**Review policy:** mandatory — freshness/invalidation and A→B reuse boundary.
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import { checkContextCapsuleFreshness } from "@/agents/context-capsule/freshness";
+import type { ContextCapsuleFrontmatter } from "@/agents/context-capsule/types";
+
+const frontmatter: ContextCapsuleFrontmatter = {
+  lifecycle_issue: 91,
+  branch: "issue-91",
+  head_sha: "abc",
+  worktree: "/root/CODE/issue-91",
+  created_at: "2026-05-17T00:00:00.000Z",
+  source_files: ["a.ts", "b.ts"],
+  source_hashes: { "a.ts": "ha", "b.ts": "hb" },
+};
+
+const base = {
+  expectedLifecycleIssue: 91,
+  branch: "issue-91",
+  headSha: "abc",
+  worktree: "/root/CODE/issue-91",
+  sourceHashes: { "a.ts": "ha", "b.ts": "hb" },
+  frontmatter,
+};
+
+describe("checkContextCapsuleFreshness", () => {
+  it("returns fresh when all hard boundaries and hashes match", () => {
+    expect(checkContextCapsuleFreshness(base)).toEqual({ status: "fresh", reasons: [], staleSourceFiles: [] });
+  });
+
+  it("returns partially-stale for same issue branch worktree with HEAD or file drift", () => {
+    const result = checkContextCapsuleFreshness({ ...base, headSha: "def", sourceHashes: { "a.ts": "changed", "b.ts": "hb" } });
+    expect(result.status).toBe("partially-stale");
+    expect(result.reasons).toContain("head_sha_mismatch");
+    expect(result.staleSourceFiles).toEqual(["a.ts"]);
+  });
+
+  it("discards on lifecycle mismatch", () => {
+    expect(checkContextCapsuleFreshness({ ...base, expectedLifecycleIssue: 92 }).status).toBe("discarded");
+  });
+
+  it("discards on branch mismatch", () => {
+    expect(checkContextCapsuleFreshness({ ...base, branch: "main" }).status).toBe("discarded");
+  });
+
+  it("discards on worktree mismatch", () => {
+    expect(checkContextCapsuleFreshness({ ...base, worktree: "/root/CODE/main" }).status).toBe("discarded");
+  });
+});
+```
+
+```typescript
+import type { ContextCapsuleFreshnessInput, ContextCapsuleFreshnessResult } from "./types";
+
+const HARD_DISCARD_REASONS = new Set(["lifecycle_issue_mismatch", "branch_mismatch", "worktree_mismatch"]);
+
+function findStaleSourceFiles(
+  expected: Readonly<Record<string, string>>,
+  actual: Readonly<Record<string, string>>,
+): readonly string[] {
+  return Object.entries(expected)
+    .filter(([path, expectedHash]) => actual[path] !== expectedHash)
+    .map(([path]) => path)
+    .sort();
+}
+
+export function checkContextCapsuleFreshness(input: ContextCapsuleFreshnessInput): ContextCapsuleFreshnessResult {
+  const reasons: string[] = [];
+  if (input.frontmatter.lifecycle_issue !== input.expectedLifecycleIssue) reasons.push("lifecycle_issue_mismatch");
+  if (input.frontmatter.branch !== input.branch) reasons.push("branch_mismatch");
+  if (input.frontmatter.worktree !== input.worktree) reasons.push("worktree_mismatch");
+
+  const staleSourceFiles = findStaleSourceFiles(input.frontmatter.source_hashes, input.sourceHashes);
+  if (input.frontmatter.head_sha !== input.headSha) reasons.push("head_sha_mismatch");
+  if (staleSourceFiles.length > 0) reasons.push("source_hash_mismatch");
+
+  if (reasons.some((reason) => HARD_DISCARD_REASONS.has(reason))) {
+    return { status: "discarded", reasons, staleSourceFiles };
+  }
+  if (reasons.length > 0) {
+    return { status: "partially-stale", reasons, staleSourceFiles };
+  }
+  return { status: "fresh", reasons: [], staleSourceFiles: [] };
+}
+```
+
+**Verify:** `bun test tests/agents/context-capsule/freshness.test.ts`
+**Commit:** `feat(agents): add context capsule freshness preflight`
+
+### Task 2.3: Context Capsule Store Reader
+**File:** `src/agents/context-capsule/store.ts`
+**Test:** `tests/agents/context-capsule/store.test.ts`
+**Depends:** 1.1, 1.2
+**Domain:** general
+**Atlas-impact:** none
+**Behavior-impact:** Enables same-issue A→B reuse by locating and parsing the latest capsule file in `thoughts/shared/context-capsules/`.
+**Review policy:** mandatory — storage contract and A→B reuse.
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { findLatestContextCapsule, parseContextCapsuleDocument } from "@/agents/context-capsule/store";
+import { renderCapsuleDocument } from "@/agents/context-capsule/format";
+
+const doc = renderCapsuleDocument(
+  {
+    lifecycle_issue: 91,
+    branch: "issue-91",
+    head_sha: "abc",
+    worktree: "/root/CODE/issue-91",
+    created_at: "2026-05-17T00:00:00.000Z",
+    source_files: ["a.ts"],
+    source_hashes: { "a.ts": "ha" },
+  },
+  "body",
+);
+
+describe("context capsule store", () => {
+  it("parses frontmatter and body", () => {
+    const parsed = parseContextCapsuleDocument(doc);
+    expect(parsed.frontmatter.lifecycle_issue).toBe(91);
+    expect(parsed.frontmatter.source_hashes["a.ts"]).toBe("ha");
+    expect(parsed.body.trim()).toBe("body");
+  });
+
+  it("finds the latest capsule file by created_at", () => {
+    const dir = mkdtempSync(join(tmpdir(), "capsule-store-"));
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "2026-05-16-old.md"), doc.replace("2026-05-17T00:00:00.000Z", "2026-05-16T00:00:00.000Z"));
+    writeFileSync(join(dir, "2026-05-17-new.md"), doc);
+
+    const latest = findLatestContextCapsule(dir);
+    expect(latest?.path.endsWith("2026-05-17-new.md")).toBe(true);
+    expect(latest?.sha).toHaveLength(64);
+  });
+
+  it("returns null when no capsule directory exists", () => {
+    expect(findLatestContextCapsule(join(tmpdir(), "missing-capsules"))).toBeNull();
+  });
+});
+```
+
+```typescript
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { createCapsuleToken, hashText } from "./format";
+import type { ContextCapsuleFrontmatter, ContextCapsuleRef } from "./types";
+
+interface ParsedContextCapsule {
+  readonly frontmatter: ContextCapsuleFrontmatter;
+  readonly body: string;
+}
+
+const FRONTMATTER_PATTERN = /^---\n([\s\S]*?)\n---\n?([\s\S]*)$/;
+
+function normalizeFrontmatter(value: unknown): ContextCapsuleFrontmatter {
+  const record = value as Partial<ContextCapsuleFrontmatter>;
+  return {
+    lifecycle_issue: typeof record.lifecycle_issue === "number" ? record.lifecycle_issue : null,
+    branch: String(record.branch ?? ""),
+    head_sha: String(record.head_sha ?? ""),
+    worktree: String(record.worktree ?? ""),
+    created_at: String(record.created_at ?? ""),
+    source_files: Array.isArray(record.source_files) ? record.source_files.map(String) : [],
+    source_hashes:
+      typeof record.source_hashes === "object" && record.source_hashes !== null
+        ? Object.fromEntries(Object.entries(record.source_hashes as Record<string, unknown>).map(([key, hash]) => [key, String(hash)]))
+        : {},
+  };
+}
+
+export function parseContextCapsuleDocument(document: string): ParsedContextCapsule {
+  const match = FRONTMATTER_PATTERN.exec(document);
+  if (!match) throw new Error("Invalid context capsule document: missing frontmatter");
+  const frontmatter = normalizeFrontmatter(parseYaml(match[1]) as unknown);
+  return { frontmatter, body: match[2] ?? "" };
+}
+
+export function findLatestContextCapsule(directory = join("thoughts", "shared", "context-capsules")): ContextCapsuleRef | null {
+  if (!existsSync(directory)) return null;
+  const candidates = readdirSync(directory)
+    .filter((file) => file.endsWith(".md"))
+    .map((file) => {
+      const path = join(directory, file);
+      const content = readFileSync(path, "utf-8");
+      const parsed = parseContextCapsuleDocument(content);
+      return { path, content, frontmatter: parsed.frontmatter };
+    })
+    .sort((left, right) => right.frontmatter.created_at.localeCompare(left.frontmatter.created_at));
+
+  const latest = candidates[0];
+  if (!latest) return null;
+  return {
+    path: latest.path,
+    content: latest.content,
+    sha: hashText(latest.content),
+    token: createCapsuleToken(latest.frontmatter),
+  };
+}
+```
+
+**Verify:** `bun test tests/agents/context-capsule/store.test.ts`
+**Commit:** `feat(agents): add context capsule store reader`
+
+### Task 2.4: Context Capsule Prompt Injector Helper
+**File:** `src/agents/context-capsule/injector.ts`
+**Test:** `tests/agents/context-capsule/injector.test.ts`
+**Depends:** 1.1
+**Domain:** general
+**Atlas-impact:** none
+**Behavior-impact:** Provides the byte-identical `<context-capsule>` prefix rendered once and reused across parallel workers.
+**Review policy:** mandatory — cache hit and user-prompt injection behavior.
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import { applyContextCapsulePrefix, renderContextCapsulePrefix } from "@/agents/context-capsule/injector";
+
+const ref = {
+  path: "thoughts/shared/context-capsules/2026-05-17-working-context-capsule.md",
+  sha: "a".repeat(64),
+  token: "token123",
+  content: "---\nlifecycle_issue: 91\n---\n\nCapsule body\n",
+};
+
+describe("context capsule injector", () => {
+  it("renders a stable context-capsule block", () => {
+    const first = renderContextCapsulePrefix(ref);
+    const second = renderContextCapsulePrefix(ref);
+    expect(first).toBe(second);
+    expect(first).toStartWith(`<context-capsule sha="${"a".repeat(64)}" fresh-token="token123"`);
+    expect(first).toContain("Capsule body");
+    expect(first).not.toContain("lifecycle_issue: 91");
+  });
+
+  it("prefixes task prompt at the top", () => {
+    const prompt = applyContextCapsulePrefix("<spawn-meta />\nTask", ref);
+    expect(prompt.startsWith("<context-capsule")).toBe(true);
+    expect(prompt).toContain("</context-capsule>\n\n<spawn-meta />");
+  });
+
+  it("returns original prompt when capsule is absent", () => {
+    expect(applyContextCapsulePrefix("Task", null)).toBe("Task");
+  });
+});
+```
+
+```typescript
+import type { ContextCapsuleRef } from "./types";
+
+const FRONTMATTER_PATTERN = /^---\n[\s\S]*?\n---\n?/;
+
+function capsuleBody(content: string): string {
+  return content.replace(FRONTMATTER_PATTERN, "").trimEnd();
+}
+
+export function renderContextCapsulePrefix(capsule: ContextCapsuleRef): string {
+  return [
+    `<context-capsule sha="${capsule.sha}" fresh-token="${capsule.token}" path="${capsule.path}">`,
+    capsuleBody(capsule.content),
+    "</context-capsule>",
+    "",
+  ].join("\n");
+}
+
+export function applyContextCapsulePrefix(prompt: string, capsule: ContextCapsuleRef | null | undefined): string {
+  if (!capsule) return prompt;
+  return `${renderContextCapsulePrefix(capsule)}${prompt}`;
+}
+```
+
+**Verify:** `bun test tests/agents/context-capsule/injector.test.ts`
+**Commit:** `feat(agents): add context capsule prompt injector`
+
+---
+
+## Batch 3: Runtime and Prompt Wiring (parallel - 8 implementers)
+
+Tasks in this batch depend on Batch 2 only where they import the new helpers. Prompt-only tasks can run after Task 1.5 but stay in this batch to keep review together.
+Tasks: 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8
+
+### Task 3.1: Spawn Agent Args Accept Optional Capsule Ref
+**File:** `src/tools/spawn-agent-args.ts`
+**Test:** `tests/tools/spawn-agent-args.test.ts`
+**Depends:** 1.1
+**Domain:** general
+**Atlas-impact:** none
+**Behavior-impact:** Lets coordinators pass a capsule reference into `spawn_agent` without introducing a new tool or changing required task fields.
+**Review policy:** mandatory — spawn-agent input schema / runtime dispatch contract.
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import { normalizeSpawnAgentArgs } from "@/tools/spawn-agent-args";
+
+const capsule = {
+  path: "thoughts/shared/context-capsules/2026-05-17-working-context-capsule.md",
+  sha: "a".repeat(64),
+  token: "token",
+  content: "---\n---\n\nCapsule body\n",
+};
+
+describe("spawn-agent args contextCapsule", () => {
+  it("preserves optional contextCapsule on tasks", () => {
+    const normalized = normalizeSpawnAgentArgs({
+      agents: [{ agent: "codebase-locator", prompt: "Find files", description: "Find", contextCapsule: capsule }],
+    });
+    expect(normalized.ok).toBe(true);
+    if (!normalized.ok) throw new Error(normalized.message);
+    expect(normalized.tasks[0].contextCapsule).toEqual(capsule);
+  });
+
+  it("rejects malformed contextCapsule", () => {
+    const normalized = normalizeSpawnAgentArgs({
+      agents: [{ agent: "codebase-locator", prompt: "Find files", description: "Find", contextCapsule: { path: 1 } }],
+    });
+    expect(normalized.ok).toBe(false);
+  });
+});
+```
+
+```typescript
+// src/tools/spawn-agent-args.ts
+import * as v from "valibot";
+
+import { normalizeSequence } from "@/tools/sequence";
+
+const ContextCapsuleRefSchema = v.object({
+  path: v.string(),
+  sha: v.string(),
+  token: v.string(),
+  content: v.string(),
+});
+
+export const AgentTaskSchema = v.object({
+  agent: v.string(),
+  prompt: v.string(),
+  description: v.string(),
+  model: v.optional(v.string()),
+  contextCapsule: v.optional(ContextCapsuleRefSchema),
+});
+
+export type AgentTask = v.InferOutput<typeof AgentTaskSchema>;
+
+export type NormalizeSpawnAgentResult =
+  | { readonly ok: true; readonly tasks: readonly AgentTask[] }
+  | { readonly ok: false; readonly message: string };
+
+export const NO_AGENTS_MESSAGE = "No agents specified.";
+export const INVALID_ARGS_MESSAGE =
+  "Invalid spawn_agent arguments: each task must provide string agent, prompt, and description fields.";
+
+const AGENTS_KEY = "agents";
+const JSON_OBJECT_PREFIX = "{";
+const JSON_ARRAY_PREFIX = "[";
+
+const failure = (message: string): NormalizeSpawnAgentResult => ({ ok: false, message });
+const success = (tasks: readonly AgentTask[]): NormalizeSpawnAgentResult => ({ ok: true, tasks });
+
+const INDEX_KEY_PATTERN = /^(?:0|[1-9]\d*)$/u;
+
+const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isIndexedRecord = (value: unknown): value is Record<string, unknown> => {
+  if (!isPlainRecord(value)) return false;
+  const keys = Object.keys(value);
+  return keys.length > 0 && keys.every((key) => INDEX_KEY_PATTERN.test(key));
+};
+
+const tryParseStringifiedJson = (value: unknown): unknown => {
+  if (typeof value !== "string") return value;
+  const text = value.trim();
+  if (!text.startsWith(JSON_OBJECT_PREFIX) && !text.startsWith(JSON_ARRAY_PREFIX)) return value;
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return value;
+  }
+};
+
+const parseSingleTask = (candidate: unknown): AgentTask | null => {
+  const parsed = v.safeParse(AgentTaskSchema, candidate);
+  return parsed.success ? parsed.output : null;
+};
+
+const parseTaskArray = (candidates: readonly unknown[]): readonly AgentTask[] | null => {
+  const tasks: AgentTask[] = [];
+  for (const candidate of candidates) {
+    const task = parseSingleTask(candidate);
+    if (task === null) return null;
+    tasks.push(task);
+  }
+  return tasks;
+};
+
+const normalizeArrayInput = (candidates: readonly unknown[]): NormalizeSpawnAgentResult => {
+  if (candidates.length === 0) return failure(NO_AGENTS_MESSAGE);
+  const tasks = parseTaskArray(candidates);
+  return tasks === null ? failure(INVALID_ARGS_MESSAGE) : success(tasks);
+};
+
+const normalizeAgentsKey = (value: unknown): NormalizeSpawnAgentResult => {
+  const decoded = tryParseStringifiedJson(value);
+  if (Array.isArray(decoded)) return normalizeArrayInput(decoded);
+  const single = parseSingleTask(decoded);
+  if (single !== null) return success([single]);
+  if (isIndexedRecord(decoded)) return normalizeArrayInput(normalizeSequence(decoded));
+  return failure(INVALID_ARGS_MESSAGE);
+};
+
+export function normalizeSpawnAgentArgs(input: unknown): NormalizeSpawnAgentResult {
+  const decoded = tryParseStringifiedJson(input);
+  if (Array.isArray(decoded)) return normalizeArrayInput(decoded);
+  if (!isPlainRecord(decoded)) return failure(INVALID_ARGS_MESSAGE);
+  if (Object.hasOwn(decoded, AGENTS_KEY)) return normalizeAgentsKey(decoded[AGENTS_KEY]);
+  const single = parseSingleTask(decoded);
+  if (single !== null) return success([single]);
+  if (isIndexedRecord(decoded)) return normalizeArrayInput(normalizeSequence(decoded));
+  return failure(INVALID_ARGS_MESSAGE);
+}
+```
+
+**Verify:** `bun test tests/tools/spawn-agent-args.test.ts`
+**Commit:** `feat(tools): accept context capsule refs in spawn agent args`
+
+### Task 3.2: Spawn Agent User Prompt Capsule Injection
+**File:** `src/tools/spawn-agent/tool.ts`
+**Test:** `tests/tools/spawn-agent.test.ts`
+**Depends:** 2.4, 3.1
+**Domain:** general
+**Atlas-impact:** none
+**Behavior-impact:** Injects capsule into spawned user prompt TOP, preserves system prompt untouched, and keeps parallel prompts byte-identical for the capsule segment.
+**Review policy:** mandatory — runtime prompt assembly / cache behavior / no system prompt changes.
+
+```typescript
+// Add these tests to tests/tools/spawn-agent.test.ts
+
+describe("spawn_agent context capsule injection", () => {
+  it("prefixes every spawned user prompt with the same capsule bytes", async () => {
+    const fake = createFakeCtx();
+    const toolDef = createSpawnAgentTool(fake.ctx);
+    const contextCapsule = {
+      path: "thoughts/shared/context-capsules/2026-05-17-working-context-capsule.md",
+      sha: "a".repeat(64),
+      token: "token123",
+      content: "---\nlifecycle_issue: 91\n---\n\nCapsule body\n",
+    };
+
+    await callExecute(toolDef, {
+      agents: [
+        { ...taskA, prompt: "task delta A", contextCapsule },
+        { ...taskB, prompt: "task delta B", contextCapsule },
+      ],
+    });
+
+    const [first, second] = fake.recorder.promptCalls.map((call) => call.text);
+    expect(first.startsWith("<context-capsule")).toBe(true);
+    expect(second.startsWith("<context-capsule")).toBe(true);
+    const firstCapsule = first.slice(0, first.indexOf("task delta A"));
+    const secondCapsule = second.slice(0, second.indexOf("task delta B"));
+    expect(firstCapsule).toBe(secondCapsule);
+    expect(firstCapsule).toContain("Capsule body");
+    expect(firstCapsule).not.toContain("lifecycle_issue: 91");
+  });
+});
+```
+
+```typescript
+// In src/tools/spawn-agent/tool.ts:
+// 1. Add import near other imports:
+import { applyContextCapsulePrefix } from "@/agents/context-capsule/injector";
+
+// 2. Replace buildPromptBody implementation with:
+function buildPromptBody(
+  task: AgentTask,
+  model: ModelReference | null,
+): { parts: { type: "text"; text: string }[]; agent: string; model?: ModelReference } {
+  const prompt = applyContextCapsulePrefix(task.prompt, task.contextCapsule);
+  const base = { parts: [{ type: "text" as const, text: prompt }], agent: task.agent };
+  return model ? { ...base, model } : base;
+}
+```
+
+**Verify:** `bun test tests/tools/spawn-agent.test.ts`
+**Commit:** `feat(tools): inject context capsules into spawned prompts`
+
+### Task 3.3: Knowledge Context Section Capsule Status Line
+**File:** `src/agents/knowledge-context-section.ts`
+**Test:** `tests/agents/knowledge-context-section.test.ts`
+**Depends:** 1.1
+**Domain:** general
+**Atlas-impact:** layer-update
+**Behavior-impact:** Adds `Capsule status: <none|fresh|partially-stale|discarded|skipped:<reason>|blocked:<reason>>` to every terminal knowledge-context section.
+**Review policy:** mandatory — user-visible response-UX and shared prompt single source.
+
+```typescript
+// Add to tests/agents/knowledge-context-section.test.ts
+
+it("declares the Capsule status terminal line", () => {
+  expect(KNOWLEDGE_CONTEXT_SECTION).toContain("Capsule status:");
+  expect(KNOWLEDGE_CONTEXT_SECTION).toContain("none|fresh|partially-stale|discarded|skipped:<reason>|blocked:<reason>");
+});
+```
+
+```typescript
+// In src/agents/knowledge-context-section.ts, replace the status tail inside KNOWLEDGE_CONTEXT_SECTION with:
+本段结尾固定附三行状态：
+\`Atlas status: <value>\`
+\`Project Memory status: <value>\`
+\`Capsule status: <none|fresh|partially-stale|discarded|skipped:<reason>|blocked:<reason>>\`
+取值参见各自协议块的 status enum；Capsule status 表示本轮是否生成 / 复用 / 丢弃 / 跳过 / 阻断 Working Context Capsule。
+```
+
+**Verify:** `bun test tests/agents/knowledge-context-section.test.ts tests/agents/effect-first-reporting.test.ts`
+**Commit:** `feat(agents): report context capsule status in knowledge context`
+
+### Task 3.4: Brainstormer Context Capsule Protocol Injection
+**File:** `src/agents/brainstormer.ts`
+**Test:** `tests/agents/context-capsule-drift-guard.test.ts`
+**Depends:** 1.5
+**Domain:** general
+**Atlas-impact:** layer-update
+**Behavior-impact:** Makes brainstormer generate/use capsules before Lens Swarm, critic/adversarial fan-out, codebase exploration fan-out, and same-lifecycle A→B reuse.
+**Review policy:** mandatory — primary agent prompt and workflow contract.
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import { brainstormerAgent } from "@/agents/brainstormer";
+import { CONTEXT_CAPSULE_PROTOCOL } from "@/agents/context-capsule-protocol";
+
+describe("context capsule drift guard", () => {
+  it("injects the shared protocol into brainstormer", () => {
+    expect(brainstormerAgent.prompt).toContain(CONTEXT_CAPSULE_PROTOCOL);
+    expect(brainstormerAgent.prompt).toContain("Lens Swarm");
+    expect(brainstormerAgent.prompt).toContain("A→B");
+  });
+});
+```
+
+```typescript
+// In src/agents/brainstormer.ts:
+// 1. Add import:
+import { CONTEXT_CAPSULE_PROTOCOL } from "./context-capsule-protocol";
+
+// 2. Inject after LENS_SWARM_PROTOCOL or near project-memory/atlas protocols:
+${CONTEXT_CAPSULE_PROTOCOL}
+
+// 3. Add a brainstormer-specific operational note after the shared block:
+<context-capsule-brainstormer-usage priority="high">
+Before Lens Swarm, Adversarial Swarm, critic fan-out, or parallel codebase exploration, build or reuse a Context Capsule from already-read design / Atlas / Project Memory / code facts, then pass the same contextCapsule object to every parallel worker. For same lifecycle A→B requests, run freshness preflight before reuse and surface Capsule status in the terminal knowledge context.
+</context-capsule-brainstormer-usage>
+```
+
+**Verify:** `bun test tests/agents/context-capsule-drift-guard.test.ts`
+**Commit:** `feat(agents): add capsule protocol to brainstormer`
+
+### Task 3.5: Commander Context Capsule Protocol Injection
+**File:** `src/agents/commander.ts`
+**Test:** `tests/agents/context-capsule-drift-guard.test.ts`
+**Depends:** 1.5
+**Domain:** general
+**Atlas-impact:** layer-update
+**Behavior-impact:** Makes commander preserve the same capsule semantics for codebase exploration fan-out and same-lifecycle sequential work while keeping primary-user reports decision-minimal.
+**Review policy:** mandatory — primary agent prompt and workflow contract.
+
+```typescript
+// Extend tests/agents/context-capsule-drift-guard.test.ts
+import { primaryAgent as commanderAgent } from "@/agents/commander";
+
+it("injects the shared protocol into commander", () => {
+  expect(commanderAgent.prompt).toContain(CONTEXT_CAPSULE_PROTOCOL);
+  expect(commanderAgent.prompt).toContain("A→B");
+  expect(commanderAgent.prompt).toContain("Capsule status");
+});
+```
+
+```typescript
+// In src/agents/commander.ts:
+// 1. Add import:
+import { CONTEXT_CAPSULE_PROTOCOL } from "./context-capsule-protocol";
+
+// 2. Inject the same shared protocol block:
+${CONTEXT_CAPSULE_PROTOCOL}
+
+// 3. Add commander-specific operational note:
+<context-capsule-commander-usage priority="high">
+When commander coordinates parallel codebase exploration or continues A→B within the same lifecycle issue, use Context Capsule as a user-prompt top prefix only. Keep user-facing recovery and terminal reports decision-minimal; expose only Capsule status, capsule path when relevant, and acceptance-oriented verification.
+</context-capsule-commander-usage>
+```
+
+**Verify:** `bun test tests/agents/context-capsule-drift-guard.test.ts`
+**Commit:** `feat(agents): add capsule protocol to commander`
+
+### Task 3.6: Executor Context Capsule Protocol Injection
+**File:** `src/agents/executor.ts`
+**Test:** `tests/agents/context-capsule-drift-guard.test.ts`
+**Depends:** 1.5
+**Domain:** general
+**Atlas-impact:** layer-update
+**Behavior-impact:** Makes executor build a batch capsule before implementer/reviewer fan-out while preserving `<context-brief>` as the mandatory per-task delta.
+**Review policy:** mandatory — executor/reviewer contract and context-brief schema boundary.
+
+```typescript
+// Extend tests/agents/context-capsule-drift-guard.test.ts
+import { executorAgent } from "@/agents/executor";
+
+it("injects the shared protocol into executor and preserves context-brief ordering", () => {
+  const prompt = executorAgent.prompt ?? "";
+  expect(prompt).toContain(CONTEXT_CAPSULE_PROTOCOL);
+  expect(prompt).toContain("capsule in front, context-brief after");
+  expect(prompt).toContain("<context-brief");
+});
+```
+
+```typescript
+// In src/agents/executor.ts:
+// 1. Add import:
+import { CONTEXT_CAPSULE_PROTOCOL } from "./context-capsule-protocol";
+
+// 2. Inject shared protocol near context-brief protocol:
+${CONTEXT_CAPSULE_PROTOCOL}
+
+// 3. Add executor-specific note:
+<context-capsule-executor-usage priority="critical">
+Before every implementer/reviewer batch fan-out, build or reuse one batch Context Capsule from the plan, frozen contract (if any), Behavior commitments, already-read Atlas / Project Memory summaries, and batch-wide confirmed facts. Pass the exact same contextCapsule object to every worker in that batch. The user prompt order is capsule in front, context-brief after, task-specific instructions last. The <context-brief> remains mandatory and per-task; capsule never replaces review policy, Behavior mapping, or must-still-verify target-file reads.
+</context-capsule-executor-usage>
+```
+
+**Verify:** `bun test tests/agents/context-capsule-drift-guard.test.ts tests/agents/leaf-no-knowledge-write.test.ts`
+**Commit:** `feat(agents): add capsule protocol to executor`
+
+### Task 3.7: Mindmodel Orchestrator Capsule Protocol Note
+**File:** `src/agents/mindmodel/orchestrator.ts`
+**Test:** `tests/agents/mindmodel/orchestrator.test.ts`
+**Depends:** 1.5
+**Domain:** general
+**Atlas-impact:** none
+**Behavior-impact:** Covers S-tier `mm-orchestrator` parallel analysis fan-out by forwarding one capsule to all Phase 1 workers.
+**Review policy:** mandatory — agent prompt contract / S-tier coverage.
+
+```typescript
+// Add to tests/agents/mindmodel/orchestrator.test.ts
+
+it("requires context capsule reuse for parallel Phase 1 fan-out", () => {
+  expect(mindmodelOrchestratorAgent.prompt).toContain("Context Capsule");
+  expect(mindmodelOrchestratorAgent.prompt).toContain("same contextCapsule object");
+  expect(mindmodelOrchestratorAgent.prompt).toContain("Phase 1");
+});
+```
+
+```typescript
+// In src/agents/mindmodel/orchestrator.ts, add import if PROMPT becomes template literal with shared protocol:
+import { CONTEXT_CAPSULE_PROTOCOL } from "../context-capsule-protocol";
+
+// Add inside PROMPT after <spawn_agent-api>:
+${CONTEXT_CAPSULE_PROTOCOL}
+
+<context-capsule-mm-orchestrator-usage priority="high">
+For Phase 1 parallel analysis, create or reuse one Context Capsule from project entry/config/test discovery already known to this orchestrator and pass the same contextCapsule object to every Phase 1 worker. Phase 2 receives Phase 1 outputs as normal task-specific prompt content.
+</context-capsule-mm-orchestrator-usage>
+```
+
+**Verify:** `bun test tests/agents/mindmodel/orchestrator.test.ts`
+**Commit:** `feat(agents): cover mindmodel fanout with context capsule protocol`
+
+### Task 3.8: Atlas Initializer Capsule Protocol Note
+**File:** `src/agents/atlas-initializer.ts`
+**Test:** `tests/agents/atlas-initializer-context-capsule.test.ts`
+**Depends:** 1.5
+**Domain:** general
+**Atlas-impact:** layer-update
+**Behavior-impact:** Covers S-tier `atlas-initializer` worker fan-out while preserving Atlas as durable vault and capsule as hot-path prompt prefix only.
+**Review policy:** mandatory — Atlas workflow boundary and agent prompt contract.
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import { atlasInitializerAgent } from "@/agents/atlas-initializer";
+import { CONTEXT_CAPSULE_PROTOCOL } from "@/agents/context-capsule-protocol";
+
+describe("atlas initializer context capsule prompt", () => {
+  it("injects the shared context capsule protocol", () => {
+    const prompt = atlasInitializerAgent.prompt ?? "";
+    expect(prompt).toContain(CONTEXT_CAPSULE_PROTOCOL);
+    expect(prompt).toContain("capsule is not an atlas node");
+    expect(prompt).toContain("same contextCapsule object");
+  });
+});
+```
+
+```typescript
+// In src/agents/atlas-initializer.ts:
+// 1. Add import:
+import { CONTEXT_CAPSULE_PROTOCOL } from "./context-capsule-protocol";
+
+// 2. Inject into PROMPT before <phase-plan>:
+${CONTEXT_CAPSULE_PROTOCOL}
+
+<context-capsule-atlas-initializer-usage priority="high">
+For discovery and worker fan-out phases, pass the same contextCapsule object to parallel workers when shared project facts have already been read. The capsule is not an atlas node, not a vault update, and not Project Memory; it is only a hot-path user-prompt prefix. Atlas durable writes still happen only through the normal atlas initializer write/reconcile flow.
+</context-capsule-atlas-initializer-usage>
+```
+
+**Verify:** `bun test tests/agents/atlas-initializer-context-capsule.test.ts`
+**Commit:** `feat(agents): cover atlas initializer fanout with context capsule protocol`
+
+---
+
+## Batch 4: Integration and Drift Guards (parallel - 7 implementers)
+
+All tasks in this batch depend on Batch 3 completing.
+Tasks: 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7
+
+### Task 4.1: Agent Capsule Protocol Drift Guard
+**File:** `tests/agents/context-capsule-drift-guard.test.ts`
+**Test:** `tests/agents/context-capsule-drift-guard.test.ts`
+**Depends:** 3.4, 3.5, 3.6
+**Domain:** general
+**Atlas-impact:** none
+**Behavior-impact:** Ensures brainstormer / commander / executor all reference the same protocol source and preserve key Behavior commitments.
+**Review policy:** mandatory — drift guard for prompt contract.
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import { brainstormerAgent } from "@/agents/brainstormer";
+import { primaryAgent as commanderAgent } from "@/agents/commander";
+import { CONTEXT_CAPSULE_PROTOCOL } from "@/agents/context-capsule-protocol";
+import { executorAgent } from "@/agents/executor";
+
+const COORDINATOR_PROMPTS = [
+  ["brainstormer", brainstormerAgent.prompt ?? ""],
+  ["commander", commanderAgent.prompt ?? ""],
+  ["executor", executorAgent.prompt ?? ""],
+] as const;
+
+describe("context capsule prompt drift guard", () => {
+  it("injects the same shared protocol source into all coordinators", () => {
+    for (const [name, prompt] of COORDINATOR_PROMPTS) {
+      expect(prompt, name).toContain(CONTEXT_CAPSULE_PROTOCOL);
+    }
+  });
+
+  it("keeps critical behavior commitments present", () => {
+    for (const [name, prompt] of COORDINATOR_PROMPTS) {
+      expect(prompt, name).toContain("user prompt TOP");
+      expect(prompt, name).toContain("never system prompt");
+      expect(prompt, name).toContain("byte-identical");
+      expect(prompt, name).toContain("worker still must read its own target files");
+      expect(prompt, name).toContain("Capsule status");
+    }
+  });
+
+  it("keeps executor context-brief contract intact", () => {
+    const prompt = executorAgent.prompt ?? "";
+    expect(prompt).toContain("<context-brief");
+    expect(prompt).toContain("capsule in front, context-brief after");
+    expect(prompt).toContain("capsule never replaces review policy");
+  });
+});
+```
+
+```typescript
+// Test-only drift guard. No production implementation block.
+```
+
+**Verify:** `bun test tests/agents/context-capsule-drift-guard.test.ts`
+**Commit:** `test(agents): guard context capsule prompt protocol drift`
+
+### Task 4.2: Lens Swarm Byte-Identical Capsule Integration Test
+**File:** `tests/integration/context-capsule-lens-swarm.test.ts`
+**Test:** `tests/integration/context-capsule-lens-swarm.test.ts`
+**Depends:** 2.4, 3.2
+**Domain:** general
+**Atlas-impact:** none
+**Behavior-impact:** Verifies 5 parallel scout prompts receive the same capsule bytes at user prompt top.
+**Review policy:** mandatory — integration coverage for S-tier Lens Swarm and byte-identical cache hit.
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import type { PluginInput } from "@opencode-ai/plugin";
+import { createSpawnAgentTool } from "@/tools/spawn-agent";
+
+type ExecuteSignature = (raw: unknown, ctx: unknown) => Promise<string>;
+
+function createCtx(promptTexts: string[]): PluginInput {
+  let index = 0;
+  return {
+    directory: "/tmp/context-capsule-lens-swarm-test",
+    client: {
+      session: {
+        create: async () => ({ data: { id: `sess-${++index}` } }),
+        prompt: async (input: { body: { parts: { text: string }[] } }) => {
+          promptTexts.push(input.body.parts[0].text);
+        },
+        messages: async () => ({ data: [{ info: { role: "assistant" }, parts: [{ type: "text", text: "ok" }] }] }),
+        delete: async () => undefined,
+      },
+    },
+  } as unknown as PluginInput;
+}
+
+describe("context capsule Lens Swarm integration", () => {
+  it("injects byte-identical capsule blocks into five scout prompts", async () => {
+    const promptTexts: string[] = [];
+    const tool = createSpawnAgentTool(createCtx(promptTexts));
+    const execute = tool.execute.bind(tool) as unknown as ExecuteSignature;
+    const contextCapsule = {
+      path: "thoughts/shared/context-capsules/2026-05-17-working-context-capsule.md",
+      sha: "a".repeat(64),
+      token: "token123",
+      content: "---\nlifecycle_issue: 91\n---\n\nShared proposal context\n",
+    };
+
+    await execute(
+      {
+        agents: Array.from({ length: 5 }, (_, i) => ({
+          agent: "brainstorm-scout",
+          description: `Scout ${i}`,
+          prompt: `<spawn-meta id="${i}" />\nLens ${i}`,
+          contextCapsule,
+        })),
+      },
+      {},
+    );
+
+    expect(promptTexts).toHaveLength(5);
+    const capsuleBlocks = promptTexts.map((text) => text.slice(0, text.indexOf("<spawn-meta")));
+    expect(new Set(capsuleBlocks).size).toBe(1);
+    expect(capsuleBlocks[0]).toStartWith("<context-capsule");
+    expect(capsuleBlocks[0]).toContain("Shared proposal context");
+  });
+});
+```
+
+```typescript
+// Test-only integration coverage. No production implementation block.
+```
+
+**Verify:** `bun test tests/integration/context-capsule-lens-swarm.test.ts`
+**Commit:** `test(integration): verify lens swarm capsule byte identity`
+
+### Task 4.3: A-to-B Freshness State Integration Test
+**File:** `tests/integration/context-capsule-ab-reuse.test.ts`
+**Test:** `tests/integration/context-capsule-ab-reuse.test.ts`
+**Depends:** 2.1, 2.2, 2.3
+**Domain:** general
+**Atlas-impact:** none
+**Behavior-impact:** Verifies same-lifecycle A→B fresh, partially-stale, discarded, and blocked secret paths.
+**Review policy:** mandatory — A→B reuse boundary, freshness, and secret blocking.
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildContextCapsule } from "@/agents/context-capsule/builder";
+import { checkContextCapsuleFreshness } from "@/agents/context-capsule/freshness";
+
+const sourceFiles = [{ path: "src/agents/executor.ts", content: "executor context" }];
+
+describe("context capsule A→B reuse integration", () => {
+  it("covers fresh, partially-stale, and discarded freshness states", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "capsule-ab-"));
+    const built = await buildContextCapsule({
+      topic: "Working Context Capsule",
+      lifecycleIssue: 91,
+      branch: "issue-91",
+      headSha: "abc",
+      worktree: "/root/CODE/issue-91",
+      sourceFiles,
+      confirmedFacts: ["A completed with executor context"],
+      createdAt: new Date("2026-05-17T00:00:00.000Z"),
+      outputDir,
+    });
+    if (built.status !== "fresh") throw new Error("expected built capsule");
+
+    expect(
+      checkContextCapsuleFreshness({
+        expectedLifecycleIssue: 91,
+        branch: "issue-91",
+        headSha: "abc",
+        worktree: "/root/CODE/issue-91",
+        sourceHashes: built.frontmatter.source_hashes,
+        frontmatter: built.frontmatter,
+      }).status,
+    ).toBe("fresh");
+
+    expect(
+      checkContextCapsuleFreshness({
+        expectedLifecycleIssue: 91,
+        branch: "issue-91",
+        headSha: "changed",
+        worktree: "/root/CODE/issue-91",
+        sourceHashes: { "src/agents/executor.ts": "changed" },
+        frontmatter: built.frontmatter,
+      }).status,
+    ).toBe("partially-stale");
+
+    expect(
+      checkContextCapsuleFreshness({
+        expectedLifecycleIssue: 91,
+        branch: "main",
+        headSha: "abc",
+        worktree: "/root/CODE/issue-91",
+        sourceHashes: built.frontmatter.source_hashes,
+        frontmatter: built.frontmatter,
+      }).status,
+    ).toBe("discarded");
+  });
+
+  it("blocks secret-bearing A→B capsule writes", async () => {
+    const built = await buildContextCapsule({
+      topic: "Secret Capsule",
+      lifecycleIssue: 91,
+      branch: "issue-91",
+      headSha: "abc",
+      worktree: "/root/CODE/issue-91",
+      sourceFiles,
+      confirmedFacts: ["Authorization: Bearer abc"],
+      outputDir: mkdtempSync(join(tmpdir(), "capsule-ab-secret-")),
+    });
+    expect(built.status).toBe("blocked");
+  });
+});
+```
+
+```typescript
+// Test-only integration coverage. No production implementation block.
+```
+
+**Verify:** `bun test tests/integration/context-capsule-ab-reuse.test.ts`
+**Commit:** `test(integration): verify context capsule ab reuse states`
+
+### Task 4.4: Effect-First Capsule Status Drift Guard
+**File:** `tests/agents/effect-first-reporting.test.ts`
+**Test:** `tests/agents/effect-first-reporting.test.ts`
+**Depends:** 3.3
+**Domain:** general
+**Atlas-impact:** none
+**Behavior-impact:** Ensures all effect-first primaries expose `Capsule status:` alongside Atlas and Project Memory status.
+**Review policy:** mandatory — user-visible response-UX commitment.
+
+```typescript
+// Add inside describe("knowledge-context subsection placement") in tests/agents/effect-first-reporting.test.ts
+
+it(`${agent.name} knowledge-context subsection mentions Capsule status line`, () => {
+  const block = expandedEffectFirstBlock(agent.source);
+  expect(block).not.toBeNull();
+  const body = block ?? "";
+  expect(body).toContain("Capsule status:");
+  expect(body).toContain("none|fresh|partially-stale|discarded|skipped:<reason>|blocked:<reason>");
+});
+
+// Add in AGENTS.md mirror tests only if AGENTS.md is updated in this lifecycle:
+// expect(AGENTS_MD).toMatch(/Capsule status/);
+```
+
+```typescript
+// Test-only drift guard extension. No production implementation block.
+```
+
+**Verify:** `bun test tests/agents/effect-first-reporting.test.ts`
+**Commit:** `test(agents): guard capsule status in effect first reporting`
+
+### Task 4.5: Context Brief Preservation Regression Test
+**File:** `tests/agents/leaf-no-knowledge-write.test.ts`
+**Test:** `tests/agents/leaf-no-knowledge-write.test.ts`
+**Depends:** 3.6
+**Domain:** general
+**Atlas-impact:** none
+**Behavior-impact:** Confirms executor still requires `<context-brief>` after adding capsule protocol.
+**Review policy:** mandatory — planner/executor/reviewer contract and context-brief schema preservation.
+
+```typescript
+// Add inside describe("executor injects context-brief protocol") in tests/agents/leaf-no-knowledge-write.test.ts
+
+it("states context capsule never replaces context-brief", () => {
+  expect(executorPrompt).toContain("Context Capsule");
+  expect(executorPrompt).toContain("capsule never replaces review policy");
+  expect(executorPrompt).toContain("<context-brief");
+});
+```
+
+```typescript
+// Test-only regression guard. No production implementation block.
+```
+
+**Verify:** `bun test tests/agents/leaf-no-knowledge-write.test.ts`
+**Commit:** `test(agents): preserve context brief with capsule protocol`
+
+### Task 4.6: Knowledge Boundary Regression Test
+**File:** `tests/lifecycle/context-capsule-boundary.test.ts`
+**Test:** `tests/lifecycle/context-capsule-boundary.test.ts`
+**Depends:** 3.4, 3.5, 3.6, 3.8
+**Domain:** general
+**Atlas-impact:** none
+**Behavior-impact:** Guards that capsules are not Project Memory, not Atlas, and not lifecycle_finish/resume side effects.
+**Review policy:** mandatory — Atlas / Project Memory / lifecycle boundary.
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(__dirname, "..", "..");
+const FILES = [
+  "src/agents/context-capsule-protocol.ts",
+  "src/agents/brainstormer.ts",
+  "src/agents/commander.ts",
+  "src/agents/executor.ts",
+  "src/agents/atlas-initializer.ts",
+];
+
+describe("context capsule knowledge boundary", () => {
+  it("does not instruct agents to promote capsules to Project Memory", () => {
+    for (const file of FILES) {
+      const source = readFileSync(join(ROOT, file), "utf-8");
+      expect(source).not.toMatch(/project_memory_promote[\s\S]{0,120}capsule/i);
+    }
+  });
+
+  it("does not instruct agents to write capsules into Atlas", () => {
+    for (const file of FILES) {
+      const source = readFileSync(join(ROOT, file), "utf-8");
+      expect(source).not.toMatch(/(?:write|update|maintain)[\s\S]{0,80}atlas[\s\S]{0,80}capsule/i);
+    }
+  });
+
+  it("keeps resume_subagent out of capsule reuse semantics", () => {
+    const protocol = readFileSync(join(ROOT, "src/agents/context-capsule-protocol.ts"), "utf-8");
+    expect(protocol).toContain("Do not extend resume_subagent");
+    expect(protocol).not.toMatch(/resume_subagent\([^)]*contextCapsule/);
+  });
+});
+```
+
+```typescript
+// Test-only boundary guard. No production implementation block.
+```
+
+**Verify:** `bun test tests/lifecycle/context-capsule-boundary.test.ts`
+**Commit:** `test(lifecycle): guard context capsule knowledge boundaries`
+
+### Task 4.7: Spawn Agent Resume Regression Test
+**File:** `tests/integration/spawn-agent-allsettled.test.ts`
+**Test:** `tests/integration/spawn-agent-allsettled.test.ts`
+**Depends:** 3.2
+**Domain:** general
+**Atlas-impact:** none
+**Behavior-impact:** Confirms capsule injection does not preserve failed sessions differently and does not alter `resume_subagent` behavior.
+**Review policy:** mandatory — lifecycle/recovery/resume semantics.
+
+```typescript
+// Add to tests/integration/spawn-agent-allsettled.test.ts inside describe("spawn_agent allSettled integration")
+
+it("does not preserve context capsule state for resume_subagent", async () => {
+  const registry = createPreservedRegistry({ maxResumes: MAX_RESUMES, ttlHours: TTL_HOURS });
+  const recorder: Recorder = { promptCalls: [], deleteCalls: [] };
+  const ctx = createCtx(recorder);
+  const contextCapsule = {
+    path: "thoughts/shared/context-capsules/2026-05-17-working-context-capsule.md",
+    sha: "a".repeat(64),
+    token: "token123",
+    content: "---\nlifecycle_issue: 91\n---\n\nCapsule body\n",
+  };
+  const spawnTool = createSpawnAgentTool(ctx, {
+    registry,
+    executeAgentSession: async (_ctx, task) => {
+      expect(task.contextCapsule).toEqual(contextCapsule);
+      return { sessionId: TASK_ERROR_SESSION, output: TASK_ERROR_OUTPUT };
+    },
+  });
+
+  const spawnOutput = await callSpawnExecute(spawnTool, { agents: [{ ...TASK_ERROR_TASK, contextCapsule }] });
+  expect(spawnOutput).toContain("**Outcome**: task_error");
+  expect(registry.get(TASK_ERROR_SESSION)).toBeNull();
+
+  const resumeTool = createResumeSubagentTool(ctx, { registry });
+  const resumeOutput = await callResumeExecute(resumeTool, { session_id: TASK_ERROR_SESSION });
+  expect(resumeOutput).toContain("Session not preserved or expired.");
+  expect(resumeOutput).not.toContain("contextCapsule");
+});
+```
+
+```typescript
+// Test-only regression guard. No production implementation block.
+```
+
+**Verify:** `bun test tests/integration/spawn-agent-allsettled.test.ts`
+**Commit:** `test(integration): preserve resume behavior with context capsules`


### PR DESCRIPTION
## Summary

实现 **Working Context Capsule** 机制：primary agent（brainstormer / commander / executor）生成一份 deterministic、byte-identical 的 capsule，注入到每个被 spawn 的 subagent 的 user prompt 顶部，从而：

- 命中 provider prompt cache，跨多个并发 subagent fan-out（Lens Swarm / executor batch / critic / 探索 fan-out / mm-orchestrator / atlas-initializer）
- 在同一 lifecycle issue 内的 A→B 连续需求间复用关键事实（含 branch + HEAD SHA + 工作集 hash + lifecycle issue 的 freshness preflight）
- 在终态"本次知识上下文"段透明展示复用状态

## Spec

- Design: \`thoughts/shared/designs/2026-05-17-working-context-capsule-design.md\`
- Plan: \`thoughts/shared/plans/2026-05-17-working-context-capsule.md\`
- 24 个 bite-sized task / 4 batches / all reviewer mandatory / 227 tests pass / 0 BLOCKED

Closes #91